### PR TITLE
Use dedicated engines for history and prediction databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Streamlit for Fabric
+
+Cette application Streamlit interagit avec des bases de données SQL pour afficher des historiques et des prédictions de stocks.
+
+## Variables d'environnement
+
+Les informations de connexion sont fournies via des variables d'environnement (par exemple dans `secret.env`) :
+
+- `SQL_USER` – Nom d'utilisateur SQL.
+- `SQL_PASSWORD` – Mot de passe SQL.
+- `SQL_SERVER` – Adresse du serveur SQL.
+- `SQL_DRIVER` – Pilote ODBC à utiliser.
+- `SQL_DATABASE_HIST` – Base contenant les données historiques.
+- `SQL_DATABASE_PRED` – Base contenant les tables de prédiction.
+
+Assurez-vous que ces variables sont définies avant de lancer l'application.

--- a/pages/1_Predictions_Mai.py
+++ b/pages/1_Predictions_Mai.py
@@ -13,7 +13,7 @@ ASSOCIATED_COLORS = [
 
 from db_utils import (
     load_hist_data,
-    get_engine,
+    get_engine_pred,
 )
 
 
@@ -45,7 +45,7 @@ def filter_data(df, brands, seasons, sizes):
 
 
 def list_prediction_tables():
-    engine = get_engine()
+    engine = get_engine_pred()
     query = (
         "SELECT table_name FROM INFORMATION_SCHEMA.TABLES "
         "WHERE table_schema = 'dbo' "
@@ -57,7 +57,7 @@ def list_prediction_tables():
 
 
 def load_prediction_data(table_name):
-    engine = get_engine()
+    engine = get_engine_pred()
     query = (
         f"SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
         f"stock_prediction, price_prediction FROM dbo.{table_name}"

--- a/pages/2_Comparatif.py
+++ b/pages/2_Comparatif.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from db_utils import (
     load_hist_data,
-    get_engine,
+    get_engine_pred,
 )
 
 
@@ -46,7 +46,7 @@ def filter_data(df, brands, seasons, sizes):
 
 
 def list_prediction_tables(month: str):
-    engine = get_engine()
+    engine = get_engine_pred()
     if month.lower() == "juin":
         month_filter = "AND table_name LIKE '%_june%'"
     else:
@@ -62,7 +62,7 @@ def list_prediction_tables(month: str):
 
 
 def load_prediction_data(table_name):
-    engine = get_engine()
+    engine = get_engine_pred()
     query = (
         f"SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
         f"stock_prediction, price_prediction FROM dbo.{table_name}"

--- a/pages/3_Predictions_Juin.py
+++ b/pages/3_Predictions_Juin.py
@@ -13,7 +13,7 @@ ASSOCIATED_COLORS = [
 
 from db_utils import (
     load_hist_data,
-    get_engine,
+    get_engine_pred,
 )
 
 
@@ -45,7 +45,7 @@ def filter_data(df, brands, seasons, sizes):
 
 
 def list_prediction_tables():
-    engine = get_engine()
+    engine = get_engine_pred()
     query = (
         "SELECT table_name FROM INFORMATION_SCHEMA.TABLES "
         "WHERE table_schema = 'dbo' "
@@ -57,7 +57,7 @@ def list_prediction_tables():
 
 
 def load_prediction_data(table_name):
-    engine = get_engine()
+    engine = get_engine_pred()
     query = (
         f"SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
         f"stock_prediction, price_prediction FROM dbo.{table_name}"

--- a/pages/analyse_detailles.py
+++ b/pages/analyse_detailles.py
@@ -3,7 +3,7 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 
-from db_utils import get_engine, load_hist_data
+from db_utils import get_engine_pred, load_hist_data
 
 ASSOCIATED_COLORS = [
     "#7fbfdc",
@@ -21,7 +21,7 @@ def format_model_name(name: str) -> str:
 
 @st.cache_data
 def list_prediction_tables():
-    engine = get_engine()
+    engine = get_engine_pred()
     query = (
         "SELECT table_name FROM INFORMATION_SCHEMA.TABLES "
         "WHERE table_schema = 'dbo' "
@@ -33,7 +33,7 @@ def list_prediction_tables():
 
 @st.cache_data
 def load_prediction_data(table_name: str) -> pd.DataFrame:
-    engine = get_engine()
+    engine = get_engine_pred()
     df = pd.read_sql(f"SELECT * FROM dbo.{table_name}", engine)
     if "date_key" in df.columns:
         df["date_key"] = pd.to_datetime(df["date_key"], errors="coerce")


### PR DESCRIPTION
## Summary
- Add `get_engine_hist` and `get_engine_pred` to `db_utils` using `SQL_DATABASE_HIST` and `SQL_DATABASE_PRED`
- Update data loading functions and pages to select the appropriate engine
- Document new environment variables in README

## Testing
- `python -m py_compile db_utils.py pages/1_Predictions_Mai.py pages/2_Comparatif.py pages/3_Predictions_Juin.py pages/analyse_detailles.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aeb5fc7630832d9759c2caeea6814c