### PR TITLE
Harden SQL queries with parameter binding and table whitelists

### DIFF
--- a/pages/1_Predictions_Mai.py
+++ b/pages/1_Predictions_Mai.py
@@ -11,6 +11,8 @@ ASSOCIATED_COLORS = [
     "#45b49d",
 ]
 
+from sqlalchemy import bindparam, text
+
 from db_utils import (
     load_hist_data,
     get_engine_pred,
@@ -27,6 +29,9 @@ def format_model_name(table_name: str) -> str:
 @st.cache_data
 def load_hist_cached():
     return load_hist_data()
+
+
+ALLOWED_TABLES = {}
 
 
 @st.cache_data
@@ -46,23 +51,32 @@ def filter_data(df, brands, seasons, sizes):
 
 def list_prediction_tables():
     engine = get_engine_pred()
-    query = (
-        "SELECT table_name FROM INFORMATION_SCHEMA.TABLES "
-        "WHERE table_schema = 'dbo' "
-        "AND table_name LIKE 'fullsize_stock_pred%' "
-        "AND table_name NOT LIKE '%_june%'"
+    stmt = text(
+        """
+        SELECT table_name FROM INFORMATION_SCHEMA.TABLES
+        WHERE table_schema = 'dbo'
+          AND table_name LIKE :pattern
+          AND table_name NOT LIKE :exclude
+        """
+    ).bindparams(
+        bindparam("pattern", value="fullsize_stock_pred%"),
+        bindparam("exclude", value="%_june%"),
     )
-    df = pd.read_sql(query, engine)
-    return df["table_name"].tolist()
+    df = pd.read_sql(stmt, engine)
+    global ALLOWED_TABLES
+    ALLOWED_TABLES = {name: name for name in df["table_name"]}
+    return list(ALLOWED_TABLES.keys())
 
 
 def load_prediction_data(table_name):
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError("Table non autorisée")
     engine = get_engine_pred()
-    query = (
-        f"SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
-        f"stock_prediction, price_prediction FROM dbo.{table_name}"
+    stmt = text(
+        "SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
+        "stock_prediction, price_prediction FROM dbo." + ALLOWED_TABLES[table_name]
     )
-    df = pd.read_sql(query, engine)
+    df = pd.read_sql(stmt, engine)
     df["date_key"] = pd.to_datetime(df["date_key"])
     return df
 

--- a/pages/3_Predictions_Juin.py
+++ b/pages/3_Predictions_Juin.py
@@ -11,6 +11,8 @@ ASSOCIATED_COLORS = [
     "#45b49d",
 ]
 
+from sqlalchemy import bindparam, text
+
 from db_utils import (
     load_hist_data,
     get_engine_pred,
@@ -27,6 +29,9 @@ def format_model_name(table_name: str) -> str:
 @st.cache_data
 def load_hist_cached():
     return load_hist_data()
+
+
+ALLOWED_TABLES = {}
 
 
 @st.cache_data
@@ -46,23 +51,32 @@ def filter_data(df, brands, seasons, sizes):
 
 def list_prediction_tables():
     engine = get_engine_pred()
-    query = (
-        "SELECT table_name FROM INFORMATION_SCHEMA.TABLES "
-        "WHERE table_schema = 'dbo' "
-        "AND table_name LIKE 'fullsize_stock_pred%' "
-        "AND table_name LIKE '%_june%'"
+    stmt = text(
+        """
+        SELECT table_name FROM INFORMATION_SCHEMA.TABLES
+        WHERE table_schema = 'dbo'
+          AND table_name LIKE :pattern
+          AND table_name LIKE :include
+        """
+    ).bindparams(
+        bindparam("pattern", value="fullsize_stock_pred%"),
+        bindparam("include", value="%_june%"),
     )
-    df = pd.read_sql(query, engine)
-    return df["table_name"].tolist()
+    df = pd.read_sql(stmt, engine)
+    global ALLOWED_TABLES
+    ALLOWED_TABLES = {name: name for name in df["table_name"]}
+    return list(ALLOWED_TABLES.keys())
 
 
 def load_prediction_data(table_name):
+    if table_name not in ALLOWED_TABLES:
+        raise ValueError("Table non autorisée")
     engine = get_engine_pred()
-    query = (
-        f"SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
-        f"stock_prediction, price_prediction FROM dbo.{table_name}"
+    stmt = text(
+        "SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
+        "stock_prediction, price_prediction FROM dbo." + ALLOWED_TABLES[table_name]
     )
-    df = pd.read_sql(query, engine)
+    df = pd.read_sql(stmt, engine)
     df["date_key"] = pd.to_datetime(df["date_key"])
     return df
 


### PR DESCRIPTION
## Summary
- Replace f-string SQL with `sqlalchemy.text` and bound parameters
- Guard against injection by whitelisting selectable tables across Streamlit pages

## Testing
- `python -m py_compile pages/1_Predictions_Mai.py pages/2_Comparatif.py pages/3_Predictions_Juin.py pages/analyse_detailles.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb73c7d68832d9131a03ebdae8643