### PR TITLE
Handle SQL errors in database interactions

### DIFF
--- a/pages/2_Comparatif.py
+++ b/pages/2_Comparatif.py
@@ -4,6 +4,7 @@ import plotly.graph_objects as go
 import numpy as np
 
 from sqlalchemy import bindparam, text
+from sqlalchemy.exc import SQLAlchemyError
 
 from db_utils import (
     load_hist_data,
@@ -76,7 +77,12 @@ def list_prediction_tables(month: str):
             bindparam("pattern", value="fullsize_stock_pred%"),
             bindparam("month_pattern", value="%_june%"),
         )
-    df = pd.read_sql(stmt, engine)
+    try:
+        df = pd.read_sql(stmt, engine)
+    except SQLAlchemyError:
+        st.error("Erreur lors de la récupération des tables de prédictions.")
+        ALLOWED_TABLES.clear()
+        return []
     global ALLOWED_TABLES
     ALLOWED_TABLES = {name: name for name in df["table_name"]}
     return list(ALLOWED_TABLES.keys())
@@ -90,7 +96,11 @@ def load_prediction_data(table_name):
         "SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
         "stock_prediction, price_prediction FROM dbo." + ALLOWED_TABLES[table_name]
     )
-    df = pd.read_sql(stmt, engine)
+    try:
+        df = pd.read_sql(stmt, engine)
+    except SQLAlchemyError:
+        st.error("Erreur lors du chargement des données de prédiction.")
+        return pd.DataFrame()
     df["date_key"] = pd.to_datetime(df["date_key"])
     return df
 

--- a/pages/3_Predictions_Juin.py
+++ b/pages/3_Predictions_Juin.py
@@ -2,6 +2,8 @@ import pandas as pd
 import streamlit as st
 import plotly.graph_objects as go
 
+from sqlalchemy.exc import SQLAlchemyError
+
 ASSOCIATED_COLORS = [
     "#7fbfdc",
     "#6ba6b6",
@@ -62,7 +64,12 @@ def list_prediction_tables():
         bindparam("pattern", value="fullsize_stock_pred%"),
         bindparam("include", value="%_june%"),
     )
-    df = pd.read_sql(stmt, engine)
+    try:
+        df = pd.read_sql(stmt, engine)
+    except SQLAlchemyError:
+        st.error("Erreur lors de la récupération des tables de prédictions.")
+        ALLOWED_TABLES.clear()
+        return []
     global ALLOWED_TABLES
     ALLOWED_TABLES = {name: name for name in df["table_name"]}
     return list(ALLOWED_TABLES.keys())
@@ -76,7 +83,11 @@ def load_prediction_data(table_name):
         "SELECT date_key, tyre_brand, tyre_season_french, tyre_fullsize, "
         "stock_prediction, price_prediction FROM dbo." + ALLOWED_TABLES[table_name]
     )
-    df = pd.read_sql(stmt, engine)
+    try:
+        df = pd.read_sql(stmt, engine)
+    except SQLAlchemyError:
+        st.error("Erreur lors du chargement des données de prédiction.")
+        return pd.DataFrame()
     df["date_key"] = pd.to_datetime(df["date_key"])
     return df
 

--- a/tests/test_db_utils_error.py
+++ b/tests/test_db_utils_error.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import db_utils
+
+
+def test_load_hist_data_returns_empty_on_error(monkeypatch, caplog):
+    def fake_read_sql(query, engine):
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(db_utils, "get_engine_hist", lambda: object())
+    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
+
+    with caplog.at_level("ERROR"):
+        df = db_utils.load_hist_data()
+    assert df.empty
+    assert "Erreur lors du chargement des données historiques" in caplog.text
+
+
+def test_save_dataframe_to_table_handles_error(monkeypatch, caplog):
+    df = pd.DataFrame({"a": [1]})
+
+    def fake_to_sql(self, *args, **kwargs):
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+
+    with caplog.at_level("ERROR"):
+        result = db_utils.save_dataframe_to_table(df, "tbl")
+    assert result.empty
+    assert "Erreur lors de l'enregistrement de la table" in caplog.text


### PR DESCRIPTION
## Summary
- add logging-based error handling for database reads and writes
- surface database read errors to users in Streamlit pages
- test SQL error handling by simulating connection failures

## Testing
- `pytest tests/test_db_utils_error.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb82ddd50832d9946c9119e79cf97