### PR TITLE
feat: add input sanitization and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
 
+from input_utils import sanitize_list
+
 ASSOCIATED_COLORS = [
     "#7fbfdc",
     "#6ba6b6",
@@ -167,11 +169,15 @@ def main():
         st.error("Aucune donnée disponible.")
         return
 
-    brands = st.sidebar.multiselect("Marques", sorted(df["tyre_brand"].unique()))
-    seasons = st.sidebar.multiselect(
-        "Saisons", sorted(df["tyre_season_french"].unique())
+    brands = sanitize_list(
+        st.sidebar.multiselect("Marques", sorted(df["tyre_brand"].unique()))
     )
-    sizes = st.sidebar.multiselect("Tailles", sorted(df["tyre_fullsize"].unique()))
+    seasons = sanitize_list(
+        st.sidebar.multiselect("Saisons", sorted(df["tyre_season_french"].unique()))
+    )
+    sizes = sanitize_list(
+        st.sidebar.multiselect("Tailles", sorted(df["tyre_fullsize"].unique()))
+    )
 
     if st.sidebar.button("Appliquer"):
         df = filter_data(df, brands, seasons, sizes)

--- a/input_utils.py
+++ b/input_utils.py
@@ -1,0 +1,53 @@
+import re
+from typing import Iterable, List
+
+def sanitize_input(value: str, pattern: str = r'^[\w\s-]{1,100}$') -> str:
+    """Validate and clean a single user input.
+
+    Parameters
+    ----------
+    value : str
+        Input string to validate.
+    pattern : str, optional
+        Regular expression describing the expected format.
+        Defaults to ``r'^[\\w\\s-]{1,100}$'`` allowing letters, digits,
+        spaces, underscores and hyphens (1 to 100 characters).
+
+    Returns
+    -------
+    str
+        The original string if it is valid.
+
+    Raises
+    ------
+    ValueError
+        If the input is empty or does not match the provided pattern.
+    """
+    if not isinstance(value, str) or not value or not re.fullmatch(pattern, value):
+        raise ValueError(f"Invalid input: {value!r}")
+    return value.strip()
+
+
+def sanitize_list(values: Iterable[str], pattern: str = r'^[\w\s-]{1,100}$') -> List[str]:
+    """Validate each element of an iterable using :func:`sanitize_input`.
+
+    Parameters
+    ----------
+    values : Iterable[str]
+        Iterable of strings to validate.
+    pattern : str, optional
+        Regular expression to use for validation. Same default as
+        :func:`sanitize_input`.
+
+    Returns
+    -------
+    List[str]
+        List of validated strings.
+
+    Raises
+    ------
+    ValueError
+        If any element fails validation.
+    """
+    return [sanitize_input(v, pattern) for v in values]
+

--- a/pages/0_Configuration.py
+++ b/pages/0_Configuration.py
@@ -8,6 +8,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from db_utils import get_engine_hist, get_engine_pred
 
+from input_utils import sanitize_input
+
 PLATFORM_PATTERN = r"_([A-Z]{2}_[0-9]{2})"
 
 
@@ -98,7 +100,9 @@ def main():
     platforms = sorted(
         set(hist_df["platform"].dropna()).union(set(pred_df["platform"].dropna()))
     )
-    platform = st.selectbox("Plateforme", platforms) if platforms else None
+    platform = (
+        sanitize_input(st.selectbox("Plateforme", platforms)) if platforms else None
+    )
 
     hist_tables = (
         hist_df[hist_df["platform"] == platform]["table_name"].tolist()
@@ -111,8 +115,16 @@ def main():
         else pred_df["table_name"].tolist()
     )
 
-    hist_table = st.selectbox("Table historique", hist_tables) if hist_tables else None
-    pred_table = st.selectbox("Table de prédiction", pred_tables) if pred_tables else None
+    hist_table = (
+        sanitize_input(st.selectbox("Table historique", hist_tables))
+        if hist_tables
+        else None
+    )
+    pred_table = (
+        sanitize_input(st.selectbox("Table de prédiction", pred_tables))
+        if pred_tables
+        else None
+    )
 
     if hist_table and pred_table:
         plat_hist = extract_platform(hist_table)

--- a/pages/1_Predictions_Mai.py
+++ b/pages/1_Predictions_Mai.py
@@ -5,6 +5,7 @@ import plotly.graph_objects as go
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from input_utils import sanitize_list
 ASSOCIATED_COLORS = [
     "#7fbfdc",
     "#6ba6b6",
@@ -360,19 +361,27 @@ def main():
         st.error("Aucune table de prédictions trouvée.")
         return
 
-    selected_tables = st.sidebar.multiselect(
-        "Tables de prédictions",
-        tables,
-        default=tables[:1],
-        format_func=format_model_name,
+    selected_tables = sanitize_list(
+        st.sidebar.multiselect(
+            "Tables de prédictions",
+            tables,
+            default=tables[:1],
+            format_func=format_model_name,
+        )
     )
     pred_dict = {t: load_pred_cached(t) for t in selected_tables}
 
-    brands = st.sidebar.multiselect("Marques", sorted(df_hist["tyre_brand"].unique()))
-    seasons = st.sidebar.multiselect(
-        "Saisons", sorted(df_hist["tyre_season_french"].unique())
+    brands = sanitize_list(
+        st.sidebar.multiselect("Marques", sorted(df_hist["tyre_brand"].unique()))
     )
-    sizes = st.sidebar.multiselect("Tailles", sorted(df_hist["tyre_fullsize"].unique()))
+    seasons = sanitize_list(
+        st.sidebar.multiselect(
+            "Saisons", sorted(df_hist["tyre_season_french"].unique())
+        )
+    )
+    sizes = sanitize_list(
+        st.sidebar.multiselect("Tailles", sorted(df_hist["tyre_fullsize"].unique()))
+    )
 
     if st.sidebar.button("Appliquer"):
         pred_dict_f = {t: filter_data(pred, brands, seasons, sizes) for t, pred in pred_dict.items()}

--- a/pages/2_Comparatif.py
+++ b/pages/2_Comparatif.py
@@ -11,6 +11,8 @@ from db_utils import (
     get_engine_pred,
 )
 
+from input_utils import sanitize_input, sanitize_list
+
 
 def format_model_name(table_name: str) -> str:
     """Return a display friendly model name."""
@@ -276,7 +278,7 @@ def main():
     st.image("logo.png", width=150)
     st.title("Comparaison des modèles")
 
-    month = st.sidebar.radio("Mois", ["Mai", "Juin"], index=0)
+    month = sanitize_input(st.sidebar.radio("Mois", ["Mai", "Juin"], index=0))
 
     df_hist = load_hist_cached()
     tables = list_prediction_tables(month)
@@ -284,15 +286,23 @@ def main():
         st.error("Aucune table de prédictions trouvée.")
         return
 
-    selected_tables = st.sidebar.multiselect(
-        "Tables à comparer",
-        tables,
-        default=tables,
-        format_func=format_model_name,
+    selected_tables = sanitize_list(
+        st.sidebar.multiselect(
+            "Tables à comparer",
+            tables,
+            default=tables,
+            format_func=format_model_name,
+        )
     )
-    brands = st.sidebar.multiselect("Marques", sorted(df_hist["tyre_brand"].unique()))
-    seasons = st.sidebar.multiselect("Saisons", sorted(df_hist["tyre_season_french"].unique()))
-    sizes = st.sidebar.multiselect("Tailles", sorted(df_hist["tyre_fullsize"].unique()))
+    brands = sanitize_list(
+        st.sidebar.multiselect("Marques", sorted(df_hist["tyre_brand"].unique()))
+    )
+    seasons = sanitize_list(
+        st.sidebar.multiselect("Saisons", sorted(df_hist["tyre_season_french"].unique()))
+    )
+    sizes = sanitize_list(
+        st.sidebar.multiselect("Tailles", sorted(df_hist["tyre_fullsize"].unique()))
+    )
 
     if st.sidebar.button("Appliquer"):
         df_hist_f = filter_data(df_hist, brands, seasons, sizes)

--- a/pages/3_Predictions_Juin.py
+++ b/pages/3_Predictions_Juin.py
@@ -4,6 +4,7 @@ import plotly.graph_objects as go
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from input_utils import sanitize_list
 ASSOCIATED_COLORS = [
     "#7fbfdc",
     "#6ba6b6",
@@ -359,19 +360,27 @@ def main():
         st.error("Aucune table de prédictions trouvée.")
         return
 
-    selected_tables = st.sidebar.multiselect(
-        "Tables de prédictions",
-        tables,
-        default=tables[:1],
-        format_func=format_model_name,
+    selected_tables = sanitize_list(
+        st.sidebar.multiselect(
+            "Tables de prédictions",
+            tables,
+            default=tables[:1],
+            format_func=format_model_name,
+        )
     )
     pred_dict = {t: load_pred_cached(t) for t in selected_tables}
 
-    brands = st.sidebar.multiselect("Marques", sorted(df_hist["tyre_brand"].unique()))
-    seasons = st.sidebar.multiselect(
-        "Saisons", sorted(df_hist["tyre_season_french"].unique())
+    brands = sanitize_list(
+        st.sidebar.multiselect("Marques", sorted(df_hist["tyre_brand"].unique()))
     )
-    sizes = st.sidebar.multiselect("Tailles", sorted(df_hist["tyre_fullsize"].unique()))
+    seasons = sanitize_list(
+        st.sidebar.multiselect(
+            "Saisons", sorted(df_hist["tyre_season_french"].unique())
+        )
+    )
+    sizes = sanitize_list(
+        st.sidebar.multiselect("Tailles", sorted(df_hist["tyre_fullsize"].unique()))
+    )
 
     if st.sidebar.button("Appliquer"):
         pred_dict_f = {t: filter_data(pred, brands, seasons, sizes) for t, pred in pred_dict.items()}

--- a/pages/analyse_detailles.py
+++ b/pages/analyse_detailles.py
@@ -7,6 +7,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from db_utils import get_engine_pred, load_hist_data
 
+from input_utils import sanitize_list
+
 ASSOCIATED_COLORS = [
     "#7fbfdc",
     "#6ba6b6",
@@ -97,11 +99,13 @@ if not tables:
     st.error("Aucune table de prédictions trouvée.")
     st.stop()
 
-selected_tables = st.sidebar.multiselect(
-    "Tables de prédictions",
-    tables,
-    default=tables[:1],
-    format_func=format_model_name,
+selected_tables = sanitize_list(
+    st.sidebar.multiselect(
+        "Tables de prédictions",
+        tables,
+        default=tables[:1],
+        format_func=format_model_name,
+    )
 )
 
 if not selected_tables:
@@ -111,9 +115,15 @@ if not selected_tables:
 pred_dict = {t: load_prediction_data(t) for t in selected_tables}
 all_df = pd.concat(pred_dict.values(), ignore_index=True)
 
-brands = st.sidebar.multiselect("Marques", sorted(all_df["tyre_brand"].dropna().unique()))
-seasons = st.sidebar.multiselect("Saisons", sorted(all_df["tyre_season_french"].dropna().unique()))
-sizes = st.sidebar.multiselect("Tailles", sorted(all_df["tyre_fullsize"].dropna().unique()))
+brands = sanitize_list(
+    st.sidebar.multiselect("Marques", sorted(all_df["tyre_brand"].dropna().unique()))
+)
+seasons = sanitize_list(
+    st.sidebar.multiselect("Saisons", sorted(all_df["tyre_season_french"].dropna().unique()))
+)
+sizes = sanitize_list(
+    st.sidebar.multiselect("Tailles", sorted(all_df["tyre_fullsize"].dropna().unique()))
+)
 
 if not st.sidebar.button("Appliquer"):
     st.stop()

--- a/tests/test_sanitize_input.py
+++ b/tests/test_sanitize_input.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from input_utils import sanitize_input, sanitize_list
+
+
+def test_sanitize_input_valid():
+    assert sanitize_input("Marque-1") == "Marque-1"
+
+
+@pytest.mark.parametrize("value", ["", "bad;drop", "abc$", "a" * 101])
+def test_sanitize_input_invalid(value):
+    with pytest.raises(ValueError):
+        sanitize_input(value)
+
+
+def test_sanitize_list_invalid():
+    with pytest.raises(ValueError):
+        sanitize_list(["ok", "not@ok"])


### PR DESCRIPTION
## Summary
- add reusable sanitize_input utility with regex validation
- validate sidebar inputs before filtering or querying
- cover invalid inputs with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aebb5108d8832d8a6ba1478e420285