### PR TITLE
Add executive dashboard and analysis pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,203 +1,50 @@
-import streamlit as st
 import pandas as pd
-import plotly.graph_objects as go
+import plotly.express as px
+import streamlit as st
 
-from input_utils import sanitize_list
-
-ASSOCIATED_COLORS = [
-    "#7fbfdc",
-    "#6ba6b6",
-    "#4cadb4",
-    "#78b495",
-    "#82b86a",
-    "#45b49d",
-]
-
-from db_utils import load_hist_data
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
 
-@st.cache_data
-def load_hist_cached():
-    return load_hist_data()
+st.set_page_config(page_title="Tableau de bord exécutif", layout="wide")
+st.title("Tableau de bord exécutif")
 
+with st.spinner("Chargement des données..."):
+    df = load_sample_data()
 
-def filter_data(df, brands, seasons, sizes):
-    if brands:
-        df = df[df["tyre_brand"].isin(brands)]
-    if seasons:
-        df = df[df["tyre_season_french"].isin(seasons)]
-    if sizes:
-        df = df[df["tyre_fullsize"].isin(sizes)]
-    return df
+if df.empty:
+    st.warning("Aucune donnée disponible.")
+else:
+    total_stock = int(df["stock_quantity"].sum())
+    critical_items = int((df["stock_status"] == "CRITIQUE").sum())
+    avg_criticality = float(df["criticality_score"].mean())
 
+    kpi1, kpi2, kpi3 = st.columns(3)
+    kpi1.metric("Stock total", f"{total_stock}")
+    kpi2.metric("Articles critiques", f"{critical_items}")
+    kpi3.metric("Criticité moyenne", f"{avg_criticality:.2f}")
 
-def plot_stock_by_brand(df):
-    daily_brand = (
-        df.groupby(["date_key", "tyre_brand"])["Sum_stock_quantity"].sum().reset_index()
+    daily_stock = df.groupby("date")["stock_quantity"].sum().reset_index()
+    fig_stock = px.line(
+        daily_stock,
+        x="date",
+        y="stock_quantity",
+        title="Évolution du stock",
     )
-    fig = go.Figure()
-    brands = daily_brand["tyre_brand"].unique()
-    for idx, brand in enumerate(brands):
-        data = daily_brand[daily_brand["tyre_brand"] == brand]
-        fig.add_trace(
-            go.Scatter(
-                x=data["date_key"],
-                y=data["Sum_stock_quantity"],
-                mode="lines",
-                stackgroup="one",
-                name=brand,
-                line=dict(color=ASSOCIATED_COLORS[idx % len(ASSOCIATED_COLORS)]),
-            )
-        )
-    fig.update_layout(
-        title="Stock par marque", xaxis_title="Date", yaxis_title="Stock", height=400
+    fig_stock.update_traces(line_color=ASSOCIATED_COLORS[0])
+    st.plotly_chart(fig_stock, use_container_width=True)
+
+    crit_by_cat = df.groupby("category")["criticality_score"].mean().reset_index()
+    fig_cat = px.bar(
+        crit_by_cat,
+        x="category",
+        y="criticality_score",
+        title="Criticité moyenne par catégorie",
+        color_discrete_sequence=ASSOCIATED_COLORS,
     )
-    return fig
+    st.plotly_chart(fig_cat, use_container_width=True)
 
+    st.dataframe(df.head(), use_container_width=True)
 
-def plot_stock_by_season(df):
-    daily_season = (
-        df.groupby(["date_key", "tyre_season_french"])["Sum_stock_quantity"]
-        .sum()
-        .reset_index()
-    )
-    fig = go.Figure()
-    seasons = daily_season["tyre_season_french"].unique()
-    for idx, season in enumerate(seasons):
-        data = daily_season[daily_season["tyre_season_french"] == season]
-        fig.add_trace(
-            go.Scatter(
-                x=data["date_key"],
-                y=data["Sum_stock_quantity"],
-                mode="lines",
-                stackgroup="one",
-                name=season,
-                line=dict(color=ASSOCIATED_COLORS[idx % len(ASSOCIATED_COLORS)]),
-            )
-        )
-    fig.update_layout(
-        title="Stock par saison",
-        xaxis_title="Date",
-        yaxis_title="Stock",
-        height=400,
-    )
-    return fig
-
-
-def display_summary(df):
-    daily_stock = df.groupby("date_key")["Sum_stock_quantity"].sum().reset_index()
-    last_stock = int(daily_stock.iloc[-1]["Sum_stock_quantity"])
-    avg_stock = int(daily_stock["Sum_stock_quantity"].mean())
-
-    price_filtered = df[df["Avg_supplier_price_eur"] > 0]["Avg_supplier_price_eur"]
-    price_max = float(price_filtered.max()) if not price_filtered.empty else 0
-    price_min = float(price_filtered.min()) if not price_filtered.empty else 0
-
-    col1, col2 = st.columns(2)
-    col1.metric("Dernier stock enregistré", f"{last_stock:,}")
-    col2.metric("Stock moyen quotidien", f"{avg_stock:,}")
-
-    col3, col4 = st.columns(2)
-    col3.metric("Prix maximum", f"{price_max:.2f} €")
-    col4.metric("Prix minimum", f"{price_min:.2f} €")
-
-
-def plot_stock_sum(df):
-    daily_stock = df.groupby("date_key")["Sum_stock_quantity"].sum().reset_index()
-    fig = go.Figure()
-    fig.add_trace(
-        go.Scatter(
-            x=daily_stock["date_key"],
-            y=daily_stock["Sum_stock_quantity"],
-            mode="lines+markers",
-            name="Stock total",
-            line=dict(color=ASSOCIATED_COLORS[0]),
-        )
-    )
-    fig.update_layout(
-        title="Évolution du stock total",
-        xaxis_title="Date",
-        yaxis_title="Stock",
-        height=400,
-    )
-    return fig
-
-
-def plot_price_avg(df):
-    price_filtered = df[df["Avg_supplier_price_eur"] > 0]
-    daily_price = (
-        price_filtered.groupby("date_key")["Avg_supplier_price_eur"]
-        .mean()
-        .reset_index()
-    )
-    fig = go.Figure()
-    fig.add_trace(
-        go.Scatter(
-            x=daily_price["date_key"],
-            y=daily_price["Avg_supplier_price_eur"],
-            mode="lines+markers",
-            name="Prix moyen fournisseur",
-            line=dict(color=ASSOCIATED_COLORS[1]),
-        )
-    )
-    fig.update_layout(
-        title="Évolution du prix moyen fournisseur",
-        xaxis_title="Date",
-        yaxis_title="Prix (€)",
-        height=400,
-    )
-    return fig
-
-
-def main():
-    st.set_page_config(page_title="Historique des stocks", layout="wide")
-    st.image("logo.png", width=150)
-    st.title("Historique des stocks")
-
-    st.markdown(
-        """
-        <style>
-        div[data-testid="stSidebar"] * {color: black;}
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
-
-    df = load_hist_cached()
-
-    if df.empty:
-        st.error("Aucune donnée disponible.")
-        return
-
-    brands = sanitize_list(
-        st.sidebar.multiselect("Marques", sorted(df["tyre_brand"].unique()))
-    )
-    seasons = sanitize_list(
-        st.sidebar.multiselect("Saisons", sorted(df["tyre_season_french"].unique()))
-    )
-    sizes = sanitize_list(
-        st.sidebar.multiselect("Tailles", sorted(df["tyre_fullsize"].unique()))
-    )
-
-    if st.sidebar.button("Appliquer"):
-        df = filter_data(df, brands, seasons, sizes)
-
-        display_summary(df)
-
-        fig_stock = plot_stock_sum(df)
-        st.plotly_chart(fig_stock, use_container_width=True)
-
-        fig_price = plot_price_avg(df)
-        st.plotly_chart(fig_price, use_container_width=True)
-
-        fig_brand = plot_stock_by_brand(df)
-        st.plotly_chart(fig_brand, use_container_width=True)
-
-        fig_season = plot_stock_by_season(df)
-        st.plotly_chart(fig_season, use_container_width=True)
-    else:
-        st.info("Sélectionnez vos filtres puis cliquez sur Appliquer.")
-
-
-if __name__ == "__main__":
-    main()
+    csv = df.to_csv(index=False).encode("utf-8")
+    st.download_button("Télécharger les données", csv, "dashboard.csv", "text/csv")

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,8 @@
+ASSOCIATED_COLORS = [
+    "#7fbfdc",
+    "#6ba6b6",
+    "#4cadb4",
+    "#78b495",
+    "#82b86a",
+    "#45b49d",
+]

--- a/pages/1_Analyse_Comparative.py
+++ b/pages/1_Analyse_Comparative.py
@@ -1,8 +1,51 @@
+import plotly.express as px
 import streamlit as st
 
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
-def main():
+
+def main() -> None:
+    st.set_page_config(page_title="Analyse Comparative", layout="wide")
     st.title("Analyse Comparative")
+
+    with st.spinner("Chargement des données..."):
+        df = load_sample_data()
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    status_counts = df["stock_status"].value_counts()
+    col1, col2, col3 = st.columns(3)
+    col1.metric("OK", int(status_counts.get("OK", 0)))
+    col2.metric("Rupture", int(status_counts.get("RUPTURE", 0)))
+    col3.metric("Critique", int(status_counts.get("CRITIQUE", 0)))
+
+    avg_stock = df.groupby("category")["stock_quantity"].mean().reset_index()
+    bar_fig = px.bar(
+        avg_stock,
+        x="category",
+        y="stock_quantity",
+        title="Stock moyen par catégorie",
+        color_discrete_sequence=ASSOCIATED_COLORS,
+    )
+    st.plotly_chart(bar_fig, use_container_width=True)
+
+    line_df = df.groupby(["date", "category"])["stock_quantity"].sum().reset_index()
+    line_fig = px.line(
+        line_df,
+        x="date",
+        y="stock_quantity",
+        color="category",
+        title="Évolution par catégorie",
+        color_discrete_sequence=ASSOCIATED_COLORS,
+    )
+    st.plotly_chart(line_fig, use_container_width=True)
+
+    st.dataframe(df, use_container_width=True)
+    csv = df.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, "analyse_comparative.csv", "text/csv")
 
 
 if __name__ == "__main__":

--- a/pages/2_Analyse_Par_Categorie.py
+++ b/pages/2_Analyse_Par_Categorie.py
@@ -1,8 +1,46 @@
+import plotly.express as px
 import streamlit as st
 
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
-def main():
+
+def main() -> None:
+    st.set_page_config(page_title="Analyse par catégorie", layout="wide")
     st.title("Analyse par catégorie")
+
+    with st.spinner("Chargement des données..."):
+        df = load_sample_data()
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    categories = sorted(df["category"].unique())
+    category = st.selectbox("Catégorie", categories)
+    subset = df[df["category"] == category]
+
+    total_stock = int(subset["stock_quantity"].sum())
+    criticality = float(subset["criticality_score"].mean())
+    critical_items = int((subset["stock_status"] == "CRITIQUE").sum())
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Stock total", f"{total_stock}")
+    col2.metric("Criticité moyenne", f"{criticality:.2f}")
+    col3.metric("Articles critiques", f"{critical_items}")
+
+    line_fig = px.line(
+        subset,
+        x="date",
+        y="stock_quantity",
+        title=f"Évolution du stock - Catégorie {category}",
+        color_discrete_sequence=[ASSOCIATED_COLORS[0]],
+    )
+    st.plotly_chart(line_fig, use_container_width=True)
+
+    st.dataframe(subset, use_container_width=True)
+    csv = subset.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, f"categorie_{category}.csv", "text/csv")
 
 
 if __name__ == "__main__":

--- a/pages/3_Analyse_Saisonniere.py
+++ b/pages/3_Analyse_Saisonniere.py
@@ -1,8 +1,36 @@
+import plotly.express as px
 import streamlit as st
 
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
-def main():
+
+def main() -> None:
+    st.set_page_config(page_title="Analyse saisonnière", layout="wide")
     st.title("Analyse saisonnière")
+
+    with st.spinner("Chargement des données..."):
+        df = load_sample_data()
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    monthly = df.copy()
+    monthly["month"] = monthly["date"].dt.to_period("M").dt.to_timestamp()
+    monthly_summary = monthly.groupby("month")["stock_quantity"].sum().reset_index()
+    fig = px.line(
+        monthly_summary,
+        x="month",
+        y="stock_quantity",
+        title="Stock total par mois",
+        color_discrete_sequence=[ASSOCIATED_COLORS[0]],
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.dataframe(monthly, use_container_width=True)
+    csv = monthly.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, "analyse_saisonniere.csv", "text/csv")
 
 
 if __name__ == "__main__":

--- a/pages/4_Predictions_Mensuelles.py
+++ b/pages/4_Predictions_Mensuelles.py
@@ -1,8 +1,38 @@
+import pandas as pd
+import plotly.express as px
 import streamlit as st
 
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
-def main():
+
+def main() -> None:
+    st.set_page_config(page_title="Prédictions mensuelles", layout="wide")
     st.title("Prédictions mensuelles")
+
+    with st.spinner("Chargement des données..."):
+        df = load_sample_data()
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    daily = df.groupby("date")["stock_quantity"].sum().reset_index()
+    daily["prediction"] = daily["stock_quantity"].rolling(7, min_periods=1).mean()
+
+    fig = px.line(
+        daily,
+        x="date",
+        y=["stock_quantity", "prediction"],
+        labels={"value": "Stock", "variable": "Série"},
+        title="Stock réel vs prédit",
+        color_discrete_sequence=ASSOCIATED_COLORS[:2],
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.dataframe(daily, use_container_width=True)
+    csv = daily.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, "predictions_mensuelles.csv", "text/csv")
 
 
 if __name__ == "__main__":

--- a/pages/5_Comparaison_Historique.py
+++ b/pages/5_Comparaison_Historique.py
@@ -1,8 +1,35 @@
+import plotly.express as px
 import streamlit as st
 
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
-def main():
+
+def main() -> None:
+    st.set_page_config(page_title="Comparaison historique", layout="wide")
     st.title("Comparaison historique")
+
+    with st.spinner("Chargement des données..."):
+        df = load_sample_data()
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    history = df.groupby(["date", "category"])["stock_quantity"].sum().reset_index()
+    fig = px.area(
+        history,
+        x="date",
+        y="stock_quantity",
+        color="category",
+        title="Comparaison historique par catégorie",
+        color_discrete_sequence=ASSOCIATED_COLORS,
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.dataframe(history, use_container_width=True)
+    csv = history.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, "comparaison_historique.csv", "text/csv")
 
 
 if __name__ == "__main__":

--- a/pages/6_Analyse_Detaillee.py
+++ b/pages/6_Analyse_Detaillee.py
@@ -1,8 +1,48 @@
+import plotly.express as px
 import streamlit as st
 
+from constants import ASSOCIATED_COLORS
+from sample_data import load_sample_data
 
-def main():
+
+def main() -> None:
+    st.set_page_config(page_title="Analyse détaillée", layout="wide")
     st.title("Analyse détaillée")
+
+    with st.spinner("Chargement des données..."):
+        df = load_sample_data()
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    statuses = ["TOUS"] + sorted(df["stock_status"].unique())
+    status = st.selectbox("Statut", statuses)
+    if status != "TOUS":
+        df = df[df["stock_status"] == status]
+
+    earliest = df["main_rupture_date"].min()
+    avg_crit = float(df["criticality_score"].mean())
+    total_stock = int(df["stock_quantity"].sum())
+
+    k1, k2, k3 = st.columns(3)
+    k1.metric("Date de rupture min", str(earliest.date()))
+    k2.metric("Criticité moyenne", f"{avg_crit:.2f}")
+    k3.metric("Stock total", f"{total_stock}")
+
+    fig = px.scatter(
+        df,
+        x="date",
+        y="criticality_score",
+        color="category",
+        title="Criticité dans le temps",
+        color_discrete_sequence=ASSOCIATED_COLORS,
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.dataframe(df, use_container_width=True)
+    csv = df.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, "analyse_detaillee.csv", "text/csv")
 
 
 if __name__ == "__main__":

--- a/sample_data.py
+++ b/sample_data.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import numpy as np
+
+
+def load_sample_data() -> pd.DataFrame:
+    """Generate sample dataframe for dashboard pages."""
+    rng = pd.date_range(pd.Timestamp.today() - pd.Timedelta(days=29), periods=30)
+    categories = ["A", "B", "C"]
+    statuses = ["OK", "RUPTURE", "CRITIQUE"]
+    data = []
+    for cat in categories:
+        for date in rng:
+            data.append(
+                {
+                    "category": cat,
+                    "date": date,
+                    "stock_status": np.random.choice(statuses),
+                    "main_rupture_date": date + pd.Timedelta(days=np.random.randint(1, 20)),
+                    "criticality_score": np.random.uniform(0, 100),
+                    "stock_quantity": np.random.randint(0, 1000),
+                }
+            )
+    return pd.DataFrame(data)


### PR DESCRIPTION
## Summary
- Replace root app with executive dashboard displaying KPIs, stock timelines and export button
- Add six interactive analysis pages covering comparisons, categories, seasonality, predictions, history and detailed views
- Centralize color palette and provide sample data generator for all pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec1cf107c832d92ed7f3bcfb1bfc8