### PR TITLE
Add reusable sidebar filter utility for Streamlit pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,13 +4,16 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 st.set_page_config(page_title="Tableau de bord exécutif", layout="wide")
-st.title("Tableau de bord exécutif")
 
 with st.spinner("Chargement des données..."):
     df = load_sample_data()
+
+_ = setup_sidebar_filters(df)
+st.title("Tableau de bord exécutif")
 
 if df.empty:
     st.warning("Aucune donnée disponible.")

--- a/pages/1_Analyse_Comparative.py
+++ b/pages/1_Analyse_Comparative.py
@@ -3,14 +3,17 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 def main() -> None:
     st.set_page_config(page_title="Analyse Comparative", layout="wide")
-    st.title("Analyse Comparative")
 
     with st.spinner("Chargement des données..."):
         df = load_sample_data()
+
+    _ = setup_sidebar_filters(df)
+    st.title("Analyse Comparative")
 
     if df.empty:
         st.warning("Aucune donnée disponible.")

--- a/pages/2_Analyse_Par_Categorie.py
+++ b/pages/2_Analyse_Par_Categorie.py
@@ -3,14 +3,17 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 def main() -> None:
     st.set_page_config(page_title="Analyse par catégorie", layout="wide")
-    st.title("Analyse par catégorie")
 
     with st.spinner("Chargement des données..."):
         df = load_sample_data()
+
+    _ = setup_sidebar_filters(df)
+    st.title("Analyse par catégorie")
 
     if df.empty:
         st.warning("Aucune donnée disponible.")

--- a/pages/3_Analyse_Saisonniere.py
+++ b/pages/3_Analyse_Saisonniere.py
@@ -3,14 +3,17 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 def main() -> None:
     st.set_page_config(page_title="Analyse saisonnière", layout="wide")
-    st.title("Analyse saisonnière")
 
     with st.spinner("Chargement des données..."):
         df = load_sample_data()
+
+    _ = setup_sidebar_filters(df)
+    st.title("Analyse saisonnière")
 
     if df.empty:
         st.warning("Aucune donnée disponible.")

--- a/pages/4_Predictions_Mensuelles.py
+++ b/pages/4_Predictions_Mensuelles.py
@@ -4,14 +4,17 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 def main() -> None:
     st.set_page_config(page_title="Prédictions mensuelles", layout="wide")
-    st.title("Prédictions mensuelles")
 
     with st.spinner("Chargement des données..."):
         df = load_sample_data()
+
+    _ = setup_sidebar_filters(df)
+    st.title("Prédictions mensuelles")
 
     if df.empty:
         st.warning("Aucune donnée disponible.")

--- a/pages/5_Comparaison_Historique.py
+++ b/pages/5_Comparaison_Historique.py
@@ -3,14 +3,17 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 def main() -> None:
     st.set_page_config(page_title="Comparaison historique", layout="wide")
-    st.title("Comparaison historique")
 
     with st.spinner("Chargement des données..."):
         df = load_sample_data()
+
+    _ = setup_sidebar_filters(df)
+    st.title("Comparaison historique")
 
     if df.empty:
         st.warning("Aucune donnée disponible.")

--- a/pages/6_Analyse_Detaillee.py
+++ b/pages/6_Analyse_Detaillee.py
@@ -3,14 +3,17 @@ import streamlit as st
 
 from constants import ASSOCIATED_COLORS
 from sample_data import load_sample_data
+from ui_utils import setup_sidebar_filters
 
 
 def main() -> None:
     st.set_page_config(page_title="Analyse détaillée", layout="wide")
-    st.title("Analyse détaillée")
 
     with st.spinner("Chargement des données..."):
         df = load_sample_data()
+
+    _ = setup_sidebar_filters(df)
+    st.title("Analyse détaillée")
 
     if df.empty:
         st.warning("Aucune donnée disponible.")

--- a/tests/test_ui_utils.py
+++ b/tests/test_ui_utils.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import types
+
+import streamlit as st
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import db_utils
+from ui_utils import setup_sidebar_filters
+
+
+def test_setup_sidebar_filters_discovers_platforms(monkeypatch):
+    monkeypatch.setattr(
+        db_utils,
+        "find_hist_tables",
+        lambda: ["fullsize_stock_hist_amz", "fullsize_stock_hist_ebay"],
+    )
+    monkeypatch.setattr(db_utils, "find_pred_tables", lambda: ["pred_amz"])
+
+    captured = {}
+
+    def selectbox(label, options):
+        captured["platform_options"] = options
+        return options[0]
+
+    dummy_sidebar = types.SimpleNamespace(
+        selectbox=selectbox,
+        radio=lambda label, options: options[0],
+        date_input=lambda label, value=None: value,
+        multiselect=lambda label, options, default=None: default or [],
+    )
+    monkeypatch.setattr(st, "sidebar", dummy_sidebar)
+
+    filters = setup_sidebar_filters()
+    assert captured["platform_options"] == ["amz", "ebay"]
+    assert filters["platform"] == "amz"

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -1,0 +1,81 @@
+import datetime
+from typing import Any, Dict, List, Optional
+
+import streamlit as st
+
+import db_utils
+
+
+def _discover_platforms() -> List[str]:
+    """Discover platform names from available database tables.
+
+    Returns
+    -------
+    List[str]
+        Sorted unique platform names extracted from historical and
+        prediction table names.
+    """
+    tables = db_utils.find_hist_tables() + db_utils.find_pred_tables()
+    platforms = {
+        tbl.replace("fullsize_stock_hist_", "").replace("pred_", "")
+        for tbl in tables
+    }
+    return sorted(platforms)
+
+
+def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:
+    """Render common sidebar filters and return selected values.
+
+    Parameters
+    ----------
+    df : Optional[pandas.DataFrame]
+        DataFrame used to populate brand, season and size options if
+        provided. The function only checks for the relevant column names
+        and ignores the DataFrame structure otherwise.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing the selected filter values.
+    """
+    platforms = _discover_platforms()
+    platform = (
+        st.sidebar.selectbox("Plateforme", platforms)
+        if platforms
+        else st.sidebar.text_input("Plateforme", "")
+    )
+
+    activity_type = st.sidebar.radio("Type d'activité", ["Historique", "Prédiction"])
+    date = st.sidebar.date_input("Date", datetime.date.today())
+
+    brand_options: List[str] = []
+    season_options: List[str] = []
+    size_options: List[str] = []
+
+    if df is not None:
+        try:
+            import pandas as pd  # type: ignore
+        except Exception:  # pragma: no cover - pandas always available in app
+            pd = None  # type: ignore
+        if pd is not None:
+            if "tyre_brand" in df:
+                brand_options = sorted(df["tyre_brand"].dropna().unique().tolist())
+            if "tyre_season_french" in df:
+                season_options = sorted(
+                    df["tyre_season_french"].dropna().unique().tolist()
+                )
+            if "tyre_fullsize" in df:
+                size_options = sorted(df["tyre_fullsize"].dropna().unique().tolist())
+
+    brands = st.sidebar.multiselect("Marques", brand_options, default=brand_options)
+    seasons = st.sidebar.multiselect("Saisons", season_options, default=season_options)
+    sizes = st.sidebar.multiselect("Tailles", size_options, default=size_options)
+
+    return {
+        "platform": platform,
+        "activity_type": activity_type,
+        "date": date,
+        "brands": brands,
+        "seasons": seasons,
+        "sizes": sizes,
+    }


### PR DESCRIPTION
## Summary
- add `setup_sidebar_filters` helper to centralize common sidebar controls
- auto-discover platforms from table names and expose activity/date/brand/season/size filters
- invoke helper across app and pages for consistent filtering
- cover platform discovery with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec35a6698832dac5b928375834dda