### PR TITLE
Sanitize user inputs and enforce SQL table whitelist

### DIFF
--- a/pages/2_Analyse_Par_Categorie.py
+++ b/pages/2_Analyse_Par_Categorie.py
@@ -2,6 +2,7 @@ import plotly.express as px
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
+from input_utils import sanitize_input
 from sample_data import load_sample_data
 from ui_utils import setup_sidebar_filters, display_dataframe
 
@@ -22,6 +23,7 @@ def main() -> None:
 
     categories = sorted(df["category"].unique())
     category = st.selectbox("Catégorie", categories)
+    category = sanitize_input(category)
     subset = df[df["category"] == category]
 
     total_stock = int(subset["stock_quantity"].sum())

--- a/pages/6_Analyse_Detaillee.py
+++ b/pages/6_Analyse_Detaillee.py
@@ -2,6 +2,7 @@ import plotly.express as px
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
+from input_utils import sanitize_input
 from sample_data import load_sample_data
 from ui_utils import setup_sidebar_filters, display_dataframe
 
@@ -22,6 +23,7 @@ def main() -> None:
 
     statuses = ["TOUS"] + sorted(df["stock_status"].unique())
     status = st.selectbox("Statut", statuses)
+    status = sanitize_input(status)
     if status != "TOUS":
         df = df[df["stock_status"] == status]
 

--- a/tests/test_db_utils_error.py
+++ b/tests/test_db_utils_error.py
@@ -15,6 +15,7 @@ def test_load_hist_data_returns_empty_on_error(monkeypatch, caplog):
 
     monkeypatch.setattr(db_utils, "get_engine_hist", lambda: object())
     monkeypatch.setattr(db_utils, "find_hist_tables", lambda: ["tbl"])
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {"tbl"})
     monkeypatch.setattr(pd, "read_sql", fake_read_sql)
 
     with caplog.at_level("ERROR"):
@@ -31,6 +32,7 @@ def test_save_dataframe_to_table_handles_error(monkeypatch, caplog):
 
     monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
     monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {"tbl"})
 
     with caplog.at_level("ERROR"):
         result = db_utils.save_dataframe_to_table(df, "tbl")

--- a/tests/test_db_utils_tables.py
+++ b/tests/test_db_utils_tables.py
@@ -51,6 +51,7 @@ def test_get_matching_tables(monkeypatch):
 def test_validate_table_consistency(monkeypatch, caplog):
     hist_table = "fullsize_stock_hist_amz_man"
     pred_table = "pred_amz_man"
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {hist_table, pred_table, "pred_ebay_man"})
 
     def fake_read_sql(query, engine):
         if "fullsize_stock_hist" in query:

--- a/tests/test_db_utils_whitelist.py
+++ b/tests/test_db_utils_whitelist.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import db_utils
+
+
+def test_find_hist_tables_respects_whitelist(monkeypatch):
+    db_utils.find_hist_tables.clear()
+    monkeypatch.setattr(db_utils, "get_engine_hist", lambda: object())
+
+    def fake_read_sql(query, engine):
+        return pd.DataFrame({"TABLE_NAME": ["fullsize_stock_hist_a", "fullsize_stock_hist_b"]})
+
+    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {"fullsize_stock_hist_b"})
+
+    assert db_utils.find_hist_tables() == ["fullsize_stock_hist_b"]
+
+
+def test_save_dataframe_to_table_disallowed(monkeypatch):
+    df = pd.DataFrame({"a": [1]})
+    monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
+    monkeypatch.setattr(pd.DataFrame, "to_sql", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", set())
+
+    with pytest.raises(ValueError):
+        db_utils.save_dataframe_to_table(df, "tbl")

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -6,6 +6,7 @@ import pandas as pd
 import streamlit as st
 
 import db_utils
+from input_utils import sanitize_input, sanitize_list
 
 
 def _discover_platforms() -> List[str]:
@@ -46,8 +47,10 @@ def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:
         if platforms
         else st.sidebar.text_input("Plateforme", "")
     )
+    platform = sanitize_input(platform) if platform else ""
 
     activity_type = st.sidebar.radio("Type d'activité", ["Historique", "Prédiction"])
+    activity_type = sanitize_input(activity_type)
     date = st.sidebar.date_input("Date", datetime.date.today())
 
     brand_options: List[str] = []
@@ -72,6 +75,11 @@ def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:
     brands = st.sidebar.multiselect("Marques", brand_options, default=brand_options)
     seasons = st.sidebar.multiselect("Saisons", season_options, default=season_options)
     sizes = st.sidebar.multiselect("Tailles", size_options, default=size_options)
+
+    # Sanitize list selections
+    brands = sanitize_list(brands)
+    seasons = sanitize_list(seasons)
+    sizes = sanitize_list(sizes)
 
     return {
         "platform": platform,


### PR DESCRIPTION
## Summary
- sanitize sidebar selections and page inputs with `sanitize_input` and `sanitize_list`
- enforce `ALLOWED_TABLES` whitelist and parameterized queries in database utils
- add tests for table whitelist handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec9f30e88832d89f9d5efa407945d