### PR TITLE
feat: add prediction data loader and real KPIs

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,50 +3,57 @@ import plotly.express as px
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
-from db_utils import load_hist_data
+from db_utils import load_hist_data, load_prediction_data
 from ui_utils import setup_sidebar_filters, display_dataframe
 
 
 st.set_page_config(page_title="Tableau de bord exécutif", layout="wide")
 
+filters = setup_sidebar_filters()
+
 progress = st.progress(0)
-df = load_hist_data()
+df_hist = load_hist_data(
+    brands=filters["brands"],
+    seasons=filters["seasons"],
+    sizes=filters["sizes"],
+)
+df_pred = load_prediction_data(
+    brands=filters["brands"],
+    seasons=filters["seasons"],
+    sizes=filters["sizes"],
+)
 progress.progress(100)
 
-_ = setup_sidebar_filters(df)
+df = df_hist if filters["activity_type"] == "Historique" else df_pred
+
 st.title("Tableau de bord exécutif")
 
 if df.empty:
     st.warning("Aucune donnée disponible.")
 else:
-    total_stock = int(df["stock_quantity"].sum())
-    critical_items = int((df["stock_status"] == "CRITIQUE").sum())
+    status_counts = df["stock_status"].value_counts()
+    critical_items = int(status_counts.get("CRITIQUE", 0))
+    next_rupture = pd.to_datetime(df["main_rupture_date"]).min()
     avg_criticality = float(df["criticality_score"].mean())
 
     kpi1, kpi2, kpi3 = st.columns(3)
-    kpi1.metric("Stock total", f"{total_stock}")
-    kpi2.metric("Articles critiques", f"{critical_items}")
+    kpi1.metric("Articles critiques", f"{critical_items}")
+    kpi2.metric(
+        "Prochaine rupture",
+        next_rupture.strftime("%Y-%m-%d") if pd.notna(next_rupture) else "N/A",
+    )
     kpi3.metric("Criticité moyenne", f"{avg_criticality:.2f}")
 
-    daily_stock = df.groupby("date")["stock_quantity"].sum().reset_index()
-    fig_stock = px.line(
-        daily_stock,
-        x="date",
-        y="stock_quantity",
-        title="Évolution du stock",
-    )
-    fig_stock.update_traces(line_color=ASSOCIATED_COLORS[0])
-    st.plotly_chart(fig_stock, use_container_width=True)
-
-    crit_by_cat = df.groupby("category")["criticality_score"].mean().reset_index()
-    fig_cat = px.bar(
-        crit_by_cat,
-        x="category",
-        y="criticality_score",
-        title="Criticité moyenne par catégorie",
+    status_df = status_counts.reset_index()
+    status_df.columns = ["stock_status", "count"]
+    fig_status = px.bar(
+        status_df,
+        x="stock_status",
+        y="count",
+        title="Répartition par statut de stock",
         color_discrete_sequence=ASSOCIATED_COLORS,
     )
-    st.plotly_chart(fig_cat, use_container_width=True)
+    st.plotly_chart(fig_status, use_container_width=True)
 
     display_dataframe(df.head())
 

--- a/tests/test_db_utils_error.py
+++ b/tests/test_db_utils_error.py
@@ -24,6 +24,21 @@ def test_load_hist_data_returns_empty_on_error(monkeypatch, caplog):
     assert "Erreur lors du chargement des données historiques" in caplog.text
 
 
+def test_load_prediction_data_returns_empty_on_error(monkeypatch, caplog):
+    def fake_read_sql(query, engine, params=None):
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
+    monkeypatch.setattr(db_utils, "find_pred_tables", lambda: ["tbl"])
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {"tbl"})
+    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
+
+    with caplog.at_level("ERROR"):
+        df = db_utils.load_prediction_data()
+    assert df.empty
+    assert "Erreur lors du chargement des données de prédiction" in caplog.text
+
+
 def test_save_dataframe_to_table_handles_error(monkeypatch, caplog):
     df = pd.DataFrame({"a": [1]})
 


### PR DESCRIPTION
## Summary
- support loading prediction data with `load_prediction_data`
- compute executive dashboard KPIs from real stock status and rupture dates
- cover prediction loader with error-handling test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeced716c8832d85c2b96b1a82bb03