### PR TITLE
feat: add prediction data loader

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import plotly.express as px
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
-from db_utils import load_hist_data, load_prediction_data
+from db_utils import load_hist_data, load_prediction_data, find_pred_tables
 from ui_utils import setup_sidebar_filters, display_dataframe
 
 
@@ -17,10 +17,17 @@ df_hist = load_hist_data(
     seasons=filters["seasons"],
     sizes=filters["sizes"],
 )
-df_pred = load_prediction_data(
-    brands=filters["brands"],
-    seasons=filters["seasons"],
-    sizes=filters["sizes"],
+pred_tables = find_pred_tables()
+pred_table = pred_tables[0] if pred_tables else None
+df_pred = (
+    load_prediction_data(
+        pred_table,
+        brands=filters["brands"],
+        seasons=filters["seasons"],
+        sizes=filters["sizes"],
+    )
+    if pred_table
+    else pd.DataFrame()
 )
 progress.progress(100)
 

--- a/tests/test_db_utils_error.py
+++ b/tests/test_db_utils_error.py
@@ -29,12 +29,11 @@ def test_load_prediction_data_returns_empty_on_error(monkeypatch, caplog):
         raise SQLAlchemyError("boom")
 
     monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
-    monkeypatch.setattr(db_utils, "find_pred_tables", lambda: ["tbl"])
     monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {"tbl"})
     monkeypatch.setattr(pd, "read_sql", fake_read_sql)
 
     with caplog.at_level("ERROR"):
-        df = db_utils.load_prediction_data()
+        df = db_utils.load_prediction_data("tbl")
     assert df.empty
     assert "Erreur lors du chargement des données de prédiction" in caplog.text
 

--- a/tests/test_db_utils_tables.py
+++ b/tests/test_db_utils_tables.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from typing import Dict
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import db_utils
@@ -78,3 +79,70 @@ def test_validate_table_consistency(monkeypatch, caplog):
 
     mismatch_pred = "pred_ebay_man"
     assert not db_utils.validate_table_consistency(hist_table, mismatch_pred)
+
+
+def test_load_prediction_data_filters(monkeypatch):
+    captured: Dict[str, object] = {}
+
+    def fake_read_sql(query, engine, params=None):
+        captured["query"] = query
+        captured["params"] = params
+        return pd.DataFrame(
+            {
+                "date_key": ["2024-01-01"],
+                "tyre_fullsize": ["205/55 R16"],
+                "tyre_brand": ["B1"],
+                "tyre_season_french": ["Ete"],
+                "stock_prediction": [1.0],
+                "price_prediction": [100.0],
+                "ic_stock_plus": [1.1],
+                "ic_stock_minus": [0.9],
+                "prediction_confidence": [0.8],
+                "stock_status": ["OK"],
+                "volatility_status": ["LOW"],
+                "main_rupture_date": ["2024-01-05"],
+                "order_recommendation": ["BUY"],
+                "tension_days": [5],
+                "recommended_volume": [10],
+                "optimal_order_date": ["2024-01-02"],
+                "last_safe_order_date": ["2024-01-03"],
+                "margin_opportunity_days": [2],
+                "criticality_score": [0.5],
+                "risk_level": ["LOW"],
+                "stability_index": [0.9],
+                "anomaly_alert": ["NONE"],
+                "seasonal_factor": [1.0],
+                "supply_chain_alert": ["NONE"],
+                "volatility_type": ["NORMAL"],
+                "procurement_urgency": ["LOW"],
+            }
+        )
+
+    monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
+    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
+    monkeypatch.setattr(db_utils, "ALLOWED_TABLES", {"tbl"})
+
+    df = db_utils.load_prediction_data(
+        "tbl",
+        brands=["B1", "B2"],
+        seasons=["Ete"],
+        sizes=["205/55 R16"],
+        start_date=pd.Timestamp("2024-01-01"),
+        end_date=pd.Timestamp("2024-01-31"),
+    )
+
+    assert not df.empty
+    assert "tbl" in captured["query"]
+    assert "tyre_brand IN (:brand0,:brand1)" in captured["query"]
+    assert "tyre_season_french IN (:season0)" in captured["query"]
+    assert "tyre_fullsize IN (:size0)" in captured["query"]
+    assert "date_key >= :start_date" in captured["query"]
+    assert "date_key <= :end_date" in captured["query"]
+    assert captured["params"]["brand0"] == "B1"
+    assert captured["params"]["brand1"] == "B2"
+    assert captured["params"]["season0"] == "Ete"
+    assert captured["params"]["size0"] == "205/55 R16"
+    assert isinstance(df.loc[0, "date_key"], pd.Timestamp)
+    assert isinstance(df.loc[0, "main_rupture_date"], pd.Timestamp)
+    assert isinstance(df.loc[0, "optimal_order_date"], pd.Timestamp)
+    assert isinstance(df.loc[0, "last_safe_order_date"], pd.Timestamp)


### PR DESCRIPTION
## Summary
- add table-aware `load_prediction_data` with brand, season, size, and date filters
- use new prediction loader in app and test suite
- verify prediction loader query filtering and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed08569e8832d9712bd394af55b43