### PR TITLE
Add rupture, price and risk analysis pages

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -310,13 +310,14 @@ def load_prediction_data(
     engine = get_engine_pred()
     query = (
         "SELECT date_key, tyre_fullsize, tyre_brand, tyre_season_french, "
-        "stock_prediction, price_prediction, ic_stock_plus, ic_stock_minus, "
-        "prediction_confidence, stock_status, volatility_status, "
-        "main_rupture_date, order_recommendation, tension_days, "
-        "recommended_volume, optimal_order_date, last_safe_order_date, "
-        "margin_opportunity_days, criticality_score, risk_level, "
-        "stability_index, anomaly_alert, seasonal_factor, "
-        "supply_chain_alert, volatility_type, procurement_urgency "
+        "stock_prediction, price_prediction, ic_price_plus, ic_price_minus, "
+        "ic_stock_plus, ic_stock_minus, prediction_confidence, stock_status, "
+        "volatility_status, main_rupture_date, order_recommendation, "
+        "tension_days, recommended_volume, optimal_order_date, "
+        "last_safe_order_date, margin_opportunity_days, criticality_score, "
+        "risk_level, stability_index, anomaly_alert, seasonal_factor, "
+        "supply_chain_alert, volatility_type, procurement_urgency, "
+        "price_jump_alert "
         f"FROM dbo.{table_name} WHERE 1=1"
     )
     params: Dict[str, object] = {}

--- a/pages/1_Gestion_Ruptures.py
+++ b/pages/1_Gestion_Ruptures.py
@@ -1,0 +1,69 @@
+import plotly.express as px
+import streamlit as st
+
+from db_utils import load_prediction_data, find_pred_tables
+from ui_utils import setup_sidebar_filters, display_dataframe
+
+
+def main() -> None:
+    st.set_page_config(page_title="Gestion des ruptures", layout="wide")
+
+    progress = st.progress(0)
+    tables = find_pred_tables()
+    if not tables:
+        st.warning("Aucune table de prédiction disponible.")
+        return
+    table_name = tables[0]
+
+    df_full = load_prediction_data(table_name)
+    progress.progress(50)
+
+    filters = setup_sidebar_filters(df_full)
+    df = load_prediction_data(
+        table_name,
+        brands=filters["brands"],
+        seasons=filters["seasons"],
+        sizes=filters["sizes"],
+    )
+    progress.progress(100)
+
+    st.title("Gestion des ruptures")
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    rupture_df = (
+        df.dropna(subset=["main_rupture_date"])  # type: ignore[arg-type]
+        .groupby("main_rupture_date")
+        .size()
+        .reset_index(name="ruptures")
+    )
+    if not rupture_df.empty:
+        fig = px.bar(
+            rupture_df,
+            x="main_rupture_date",
+            y="ruptures",
+            title="Timeline des ruptures",
+        )
+        st.plotly_chart(fig, use_container_width=True)
+    else:
+        st.info("Aucune rupture détectée.")
+
+    st.subheader("Produits critiques")
+    critical_df = df.sort_values("criticality_score", ascending=False)
+    display_dataframe(critical_df)
+
+    st.subheader("Recommandations d'achat")
+    recomm_df = (
+        df[["tyre_brand", "tyre_fullsize", "recommended_volume"]]
+        .sort_values("recommended_volume", ascending=False)
+    )
+    display_dataframe(recomm_df)
+
+    st.subheader("Données filtrées")
+    display_dataframe(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/2_Analyse_Prix.py
+++ b/pages/2_Analyse_Prix.py
@@ -1,0 +1,101 @@
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from constants import ASSOCIATED_COLORS
+from db_utils import load_prediction_data, find_pred_tables
+from ui_utils import setup_sidebar_filters, display_dataframe
+
+
+def main() -> None:
+    st.set_page_config(page_title="Analyse des prix", layout="wide")
+
+    progress = st.progress(0)
+    tables = find_pred_tables()
+    if not tables:
+        st.warning("Aucune table de prédiction disponible.")
+        return
+    table_name = tables[0]
+
+    df_full = load_prediction_data(table_name)
+    progress.progress(50)
+
+    filters = setup_sidebar_filters(df_full)
+    df = load_prediction_data(
+        table_name,
+        brands=filters["brands"],
+        seasons=filters["seasons"],
+        sizes=filters["sizes"],
+    )
+    progress.progress(100)
+
+    st.title("Analyse des prix")
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    price_df = df.dropna(subset=["price_prediction"])
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=price_df["date_key"],
+            y=price_df["price_prediction"],
+            mode="lines",
+            name="Prix",
+        )
+    )
+    if "ic_price_plus" in price_df and "ic_price_minus" in price_df:
+        fig.add_trace(
+            go.Scatter(
+                x=price_df["date_key"],
+                y=price_df["ic_price_plus"],
+                mode="lines",
+                line=dict(width=0),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=price_df["date_key"],
+                y=price_df["ic_price_minus"],
+                mode="lines",
+                line=dict(width=0),
+                fill="tonexty",
+                fillcolor="rgba(127,191,220,0.2)",
+                name="Intervalle de confiance",
+            )
+        )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.subheader("Alertes de saut de prix")
+    if "price_jump_alert" in df:
+        alerts = df[df["price_jump_alert"].notna() & (df["price_jump_alert"] != 0)]
+        if alerts.empty:
+            st.info("Aucune alerte détectée.")
+        else:
+            display_dataframe(alerts)
+    else:
+        st.info("Aucune alerte détectée.")
+
+    if "margin_opportunity_days" in df:
+        st.subheader("Opportunités de marge")
+        marg = (
+            df.groupby("tyre_brand")["margin_opportunity_days"].mean().reset_index()
+        )
+        marg_fig = px.bar(
+            marg,
+            x="tyre_brand",
+            y="margin_opportunity_days",
+            title="Jours d'opportunité de marge par marque",
+            color_discrete_sequence=ASSOCIATED_COLORS,
+        )
+        st.plotly_chart(marg_fig, use_container_width=True)
+
+    st.subheader("Données filtrées")
+    display_dataframe(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/3_Volatilite_Risques.py
+++ b/pages/3_Volatilite_Risques.py
@@ -1,0 +1,80 @@
+import plotly.express as px
+import streamlit as st
+
+from constants import ASSOCIATED_COLORS
+from db_utils import load_prediction_data, find_pred_tables
+from ui_utils import setup_sidebar_filters, display_dataframe
+
+
+def main() -> None:
+    st.set_page_config(page_title="Volatilité & Risques", layout="wide")
+
+    progress = st.progress(0)
+    tables = find_pred_tables()
+    if not tables:
+        st.warning("Aucune table de prédiction disponible.")
+        return
+    table_name = tables[0]
+
+    df_full = load_prediction_data(table_name)
+    progress.progress(50)
+
+    filters = setup_sidebar_filters(df_full)
+    df = load_prediction_data(
+        table_name,
+        brands=filters["brands"],
+        seasons=filters["seasons"],
+        sizes=filters["sizes"],
+    )
+    progress.progress(100)
+
+    st.title("Volatilité & Risques")
+
+    if df.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    if "volatility_type" in df and "volatility_status" in df:
+        vol_rank = (
+            df.groupby(["volatility_type", "volatility_status"]).size()
+            .reset_index(name="count")
+            .sort_values("count", ascending=False)
+        )
+        fig = px.bar(
+            vol_rank,
+            x="volatility_type",
+            y="count",
+            color="volatility_status",
+            title="Classement par type et statut de volatilité",
+            color_discrete_sequence=ASSOCIATED_COLORS,
+        )
+        st.plotly_chart(fig, use_container_width=True)
+        display_dataframe(vol_rank)
+
+    if "risk_level" in df:
+        risk_agg = (
+            df.groupby(["tyre_brand", "tyre_season_french", "risk_level"]).size()
+            .reset_index(name="count")
+            .sort_values("count", ascending=False)
+        )
+        st.subheader("Agrégation des niveaux de risque par marque et saison")
+        display_dataframe(risk_agg)
+
+    st.subheader("Alertes")
+    alert_mask = False
+    if "anomaly_alert" in df:
+        alert_mask |= df["anomaly_alert"].notna() & (df["anomaly_alert"] != "NONE")
+    if "supply_chain_alert" in df:
+        alert_mask |= df["supply_chain_alert"].notna() & (df["supply_chain_alert"] != "NONE")
+    alerts = df[alert_mask] if isinstance(alert_mask, bool) else df[alert_mask]
+    if alerts.empty:
+        st.info("Aucune alerte détectée.")
+    else:
+        display_dataframe(alerts)
+
+    st.subheader("Données filtrées")
+    display_dataframe(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_db_utils_tables.py
+++ b/tests/test_db_utils_tables.py
@@ -95,6 +95,8 @@ def test_load_prediction_data_filters(monkeypatch):
                 "tyre_season_french": ["Ete"],
                 "stock_prediction": [1.0],
                 "price_prediction": [100.0],
+                "ic_price_plus": [110.0],
+                "ic_price_minus": [90.0],
                 "ic_stock_plus": [1.1],
                 "ic_stock_minus": [0.9],
                 "prediction_confidence": [0.8],
@@ -115,6 +117,7 @@ def test_load_prediction_data_filters(monkeypatch):
                 "supply_chain_alert": ["NONE"],
                 "volatility_type": ["NORMAL"],
                 "procurement_urgency": ["LOW"],
+                "price_jump_alert": [0],
             }
         )
 


### PR DESCRIPTION
## Summary
- extend prediction data loading with price interval and alert fields
- add rupture management page with timeline and purchase recommendations
- add price analysis page with prediction intervals and margin insights
- add volatility & risk page summarizing risk levels and alerts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aed29a9e0c832dad459ec385b1f443