### PR TITLE
feat: add server-specific engines for historical and prediction databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ Les tables de prédiction exposent notamment :
 
 Les informations de connexion sont fournies via des variables d'environnement (par exemple dans `secret.env`) :
 
-- `SQL_USER` – Nom d'utilisateur SQL.
-- `SQL_PASSWORD` – Mot de passe SQL.
-- `SQL_SERVER` – Adresse du serveur SQL.
-- `SQL_DRIVER` – Pilote ODBC à utiliser.
-- `SQL_DATABASE_HIST` – Base contenant les données historiques.
-- `SQL_DATABASE_PRED` – Base contenant les tables de prédiction.
-- `ALLOWED_TABLES` – Liste (séparée par des virgules) des tables autorisées.
+ - `SQL_USER` – Nom d'utilisateur SQL.
+ - `SQL_PASSWORD` – Mot de passe SQL.
+ - `SQL_DRIVER` – Pilote ODBC à utiliser.
+ - `SQL_SERVER_HIST` – Adresse du serveur hébergeant les données historiques.
+ - `SQL_DATABASE_HIST` – Base contenant les données historiques.
+ - `SQL_SERVER_PRED` – Adresse du serveur des tables de prédiction.
+ - `SQL_DATABASE_PRED` – Base contenant les tables de prédiction.
+ - `ALLOWED_TABLES` – Liste (séparée par des virgules) des tables autorisées.
   Elle doit inclure chaque table SQL qu'on souhaite interroger, sinon les fonctions de chargement refuseront la requête.
 
 Assurez-vous que ces variables sont définies avant de lancer l'application et que `ALLOWED_TABLES` contient bien la whiteliste des tables disponibles.

--- a/db_utils.py
+++ b/db_utils.py
@@ -26,14 +26,17 @@ def _assert_allowed_table(table: str) -> None:
         raise ValueError(f"Table '{table}' is not allowed.")
 
 
-def _build_engine(database: str) -> Engine:
+def _build_engine(server: str, database: str) -> Engine:
+    """Create a SQLAlchemy engine for the given server and database."""
+
     user = os.getenv("SQL_USER")
     password = os.getenv("SQL_PASSWORD")
-    server = os.getenv("SQL_SERVER")
     driver = os.getenv("SQL_DRIVER")
 
     if driver is None:
-        raise ValueError("La variable d'environnement SQL_DRIVER est manquante.")
+        raise ValueError(
+            "La variable d'environnement SQL_DRIVER est manquante."
+        )
     driver = driver.replace(" ", "+")
 
     connection_string = (
@@ -47,24 +50,45 @@ def _build_engine(database: str) -> Engine:
 
 
 def get_engine_hist() -> Engine:
+    server = os.getenv("SQL_SERVER_HIST")
     database = os.getenv("SQL_DATABASE_HIST")
+    if server is None:
+        raise ValueError(
+            "La variable d'environnement SQL_SERVER_HIST est manquante."
+        )
     if database is None:
-        raise ValueError("La variable d'environnement SQL_DATABASE_HIST est manquante.")
-    return _build_engine(database)
+        raise ValueError(
+            "La variable d'environnement SQL_DATABASE_HIST est manquante."
+        )
+    return _build_engine(server, database)
 
 
 def get_engine_pred() -> Engine:
+    server = os.getenv("SQL_SERVER_PRED")
     database = os.getenv("SQL_DATABASE_PRED")
+    if server is None:
+        raise ValueError(
+            "La variable d'environnement SQL_SERVER_PRED est manquante."
+        )
     if database is None:
-        raise ValueError("La variable d'environnement SQL_DATABASE_PRED est manquante.")
-    return _build_engine(database)
+        raise ValueError(
+            "La variable d'environnement SQL_DATABASE_PRED est manquante."
+        )
+    return _build_engine(server, database)
 
 
 def get_engine() -> Engine:
+    server = os.getenv("SQL_SERVER")
     database = os.getenv("SQL_DATABASE")
+    if server is None:
+        raise ValueError(
+            "La variable d'environnement SQL_SERVER est manquante."
+        )
     if database is None:
-        raise ValueError("La variable d'environnement SQL_DATABASE est manquante.")
-    return _build_engine(database)
+        raise ValueError(
+            "La variable d'environnement SQL_DATABASE est manquante."
+        )
+    return _build_engine(server, database)
 
 
 @st.cache_data(show_spinner=False)


### PR DESCRIPTION
## Summary
- extend `_build_engine` to accept a server parameter
- add `get_engine_hist` and `get_engine_pred` using dedicated SQL servers/databases
- document new environment variables in README

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true --server.port 8501` (fails: Could not open ODBC driver library)


------
https://chatgpt.com/codex/tasks/task_e_68aed5fb16e4832d847e9b0666a73cea