### PR TITLE
Read ALLOWED_TABLES from env and validate at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Les informations de connexion sont fournies via des variables d'environnement (p
  - `SQL_DATABASE_HIST` – Base contenant les données historiques.
  - `SQL_SERVER_PRED` – Adresse du serveur des tables de prédiction.
  - `SQL_DATABASE_PRED` – Base contenant les tables de prédiction.
- - `ALLOWED_TABLES` – Liste (séparée par des virgules) des tables autorisées.
-  Elle doit inclure chaque table SQL qu'on souhaite interroger, sinon les fonctions de chargement refuseront la requête.
+ - `ALLOWED_TABLES` – Liste des tables autorisées séparées par des virgules.
+   Exemple : `pred_amz_man,pred_ebay_dis`. Chaque nom doit être séparé par une virgule,
+   sinon les fonctions de chargement refuseront la requête.
 
 Assurez-vous que ces variables sont définies avant de lancer l'application et que `ALLOWED_TABLES` contient bien la whiteliste des tables disponibles.

--- a/db_utils.py
+++ b/db_utils.py
@@ -17,7 +17,18 @@ load_dotenv("secret.env")
 logger = logging.getLogger(__name__)
 
 # Whitelist of SQL tables allowed for queries
-ALLOWED_TABLES: Set[str] = set()
+ALLOWED_TABLES: Set[str] = set(
+    filter(None, os.getenv("ALLOWED_TABLES", "").split(","))
+)
+
+_EXPECTED_TABLES: Set[str] = set(
+    filter(None, os.getenv("EXPECTED_TABLES", "").split(","))
+)
+_missing = _EXPECTED_TABLES - ALLOWED_TABLES
+if _missing:
+    raise ValueError(
+        "Les tables attendues absentes de ALLOWED_TABLES: " + ", ".join(sorted(_missing))
+    )
 
 
 def _assert_allowed_table(table: str) -> None:

--- a/tests/test_expected_tables_env.py
+++ b/tests/test_expected_tables_env.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import importlib
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def _import_db_utils(monkeypatch, allowed: str, expected: str):
+    monkeypatch.setenv("ALLOWED_TABLES", allowed)
+    monkeypatch.setenv("EXPECTED_TABLES", expected)
+    if "db_utils" in sys.modules:
+        del sys.modules["db_utils"]
+    return importlib.import_module("db_utils")
+
+
+def test_missing_expected_tables_raises(monkeypatch):
+    with pytest.raises(ValueError):
+        _import_db_utils(monkeypatch, "tbl1", "tbl1,tbl2")
+
+
+def test_expected_tables_ok(monkeypatch):
+    _import_db_utils(monkeypatch, "tbl1,tbl2", "tbl1")


### PR DESCRIPTION
## Summary
- Parse allowed table names from the `ALLOWED_TABLES` environment variable
- Validate on import that tables listed in `EXPECTED_TABLES` are whitelisted
- Document comma-separated table configuration and add tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed6fddde0832da615936d6c11b311