### PR TITLE
feat: fallback SQL env variables

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -61,29 +61,29 @@ def _build_engine(server: str, database: str) -> Engine:
 
 
 def get_engine_hist() -> Engine:
-    server = os.getenv("SQL_SERVER_HIST")
-    database = os.getenv("SQL_DATABASE_HIST")
+    server = os.getenv("SQL_SERVER_HIST") or os.getenv("SQL_SERVER")
+    database = os.getenv("SQL_DATABASE_HIST") or os.getenv("SQL_DATABASE")
     if server is None:
         raise ValueError(
-            "La variable d'environnement SQL_SERVER_HIST est manquante."
+            "Les variables d'environnement SQL_SERVER_HIST ou SQL_SERVER sont manquantes."
         )
     if database is None:
         raise ValueError(
-            "La variable d'environnement SQL_DATABASE_HIST est manquante."
+            "Les variables d'environnement SQL_DATABASE_HIST ou SQL_DATABASE sont manquantes."
         )
     return _build_engine(server, database)
 
 
 def get_engine_pred() -> Engine:
-    server = os.getenv("SQL_SERVER_PRED")
-    database = os.getenv("SQL_DATABASE_PRED")
+    server = os.getenv("SQL_SERVER_PRED") or os.getenv("SQL_SERVER")
+    database = os.getenv("SQL_DATABASE_PRED") or os.getenv("SQL_DATABASE")
     if server is None:
         raise ValueError(
-            "La variable d'environnement SQL_SERVER_PRED est manquante."
+            "Les variables d'environnement SQL_SERVER_PRED ou SQL_SERVER sont manquantes."
         )
     if database is None:
         raise ValueError(
-            "La variable d'environnement SQL_DATABASE_PRED est manquante."
+            "Les variables d'environnement SQL_DATABASE_PRED ou SQL_DATABASE sont manquantes."
         )
     return _build_engine(server, database)
 


### PR DESCRIPTION
## Summary
- allow `get_engine_hist` and `get_engine_pred` to fall back to general SQL env vars
- clarify error messages when required SQL env vars are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aee9c6a728832d879c407108a2cdca