### PR TITLE
Document pytest test usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ Un fichier d'exemple `secret.env.example` est disponible à la racine : copiez-
    requête.
 
 Assurez-vous que ces variables sont définies avant de lancer l'application et que `ALLOWED_TABLES` contient bien la whiteliste des tables disponibles.
+
+## Tests
+
+Executez la suite de tests avec [pytest](https://pytest.org/):
+
+```bash
+pytest tests/
+```

--- a/tests/test_db_utils_tables.py
+++ b/tests/test_db_utils_tables.py
@@ -149,3 +149,8 @@ def test_load_prediction_data_filters(monkeypatch):
     assert isinstance(df.loc[0, "main_rupture_date"], pd.Timestamp)
     assert isinstance(df.loc[0, "optimal_order_date"], pd.Timestamp)
     assert isinstance(df.loc[0, "last_safe_order_date"], pd.Timestamp)
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- clarify in README that the test suite runs with `pytest`
- allow running `tests/test_db_utils_tables.py` directly via `pytest`

## Testing
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68aeebbafec4832db94b1806bd72c2a0