### PR TITLE
test: silence Streamlit cache warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import logging
+import pytest
+
+@pytest.fixture(autouse=True)
+def silence_streamlit_cache_warnings():
+    logging.getLogger(
+        "streamlit.runtime.caching.cache_data_api"
+    ).setLevel(logging.ERROR)


### PR DESCRIPTION
## Summary
- silence Streamlit cache warnings during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeec46df0c832da8e78ac2244545ca