### PR TITLE
Classify DB tables by schema columns

### DIFF
--- a/tests/test_db_utils_classify_tables.py
+++ b/tests/test_db_utils_classify_tables.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import db_utils
+
+
+def test_find_tables_via_columns(monkeypatch):
+    def fake_read_sql(query, engine, params=None):
+        if "INFORMATION_SCHEMA.TABLES" in query:
+            return pd.DataFrame({"TABLE_NAME": ["hist_tbl", "pred_tbl", "other_tbl"]})
+        elif "INFORMATION_SCHEMA.COLUMNS" in query:
+            table = params["table"]
+            if table == "hist_tbl":
+                return pd.DataFrame({"COLUMN_NAME": ["Sum_stock_quantity", "foo"]})
+            if table == "pred_tbl":
+                return pd.DataFrame({"COLUMN_NAME": ["stock_prediction", "bar"]})
+            return pd.DataFrame({"COLUMN_NAME": ["foo"]})
+        raise AssertionError("Unexpected query")
+
+    monkeypatch.setattr(db_utils, "get_engine_hist", lambda: object())
+    monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
+    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
+
+    assert db_utils.find_hist_tables() == ["hist_tbl"]
+    assert db_utils.find_pred_tables() == ["pred_tbl"]


### PR DESCRIPTION
## Summary
- Query all tables and categorize historical vs. prediction tables by inspecting column names instead of relying on prefixes
- Add tests verifying table classification logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef2c36b58832dae7c053570c574df