### PR TITLE
Require explicit database variables for historical and prediction connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Un fichier d'exemple `secret.env.example` est disponible à la racine : copiez-
 - `SQL_SERVER_PRED` – Adresse du serveur des tables de prédiction.
 - `SQL_DATABASE_PRED` – Base contenant les tables de prédiction.
 
+Les variables génériques `SQL_SERVER` et `SQL_DATABASE` ne sont plus prises en
+charge ; vous devez définir explicitement les quatre variables ci-dessus.
+
 ### Conventions de nommage des tables
 
 Les tables historiques suivent le motif `fullsize_stock_hist_%` et les tables de prédiction le motif `pred_%`. Les suffixes doivent correspondre pour former une paire cohérente, par exemple : `fullsize_stock_hist_amz_man` et `pred_amz_man`.

--- a/db_utils.py
+++ b/db_utils.py
@@ -106,29 +106,29 @@ def _build_engine(server: str, database: str) -> Engine:
 
 
 def get_engine_hist() -> Engine:
-    server = os.getenv("SQL_SERVER_HIST") or os.getenv("SQL_SERVER")
-    database = os.getenv("SQL_DATABASE_HIST") or os.getenv("SQL_DATABASE")
+    server = os.getenv("SQL_SERVER_HIST")
+    database = os.getenv("SQL_DATABASE_HIST")
     if server is None:
         raise ValueError(
-            "Les variables d'environnement SQL_SERVER_HIST ou SQL_SERVER sont manquantes."
+            "La variable d'environnement SQL_SERVER_HIST est manquante."
         )
     if database is None:
         raise ValueError(
-            "Les variables d'environnement SQL_DATABASE_HIST ou SQL_DATABASE sont manquantes."
+            "La variable d'environnement SQL_DATABASE_HIST est manquante."
         )
     return _build_engine(server, database)
 
 
 def get_engine_pred() -> Engine:
-    server = os.getenv("SQL_SERVER_PRED") or os.getenv("SQL_SERVER")
-    database = os.getenv("SQL_DATABASE_PRED") or os.getenv("SQL_DATABASE")
+    server = os.getenv("SQL_SERVER_PRED")
+    database = os.getenv("SQL_DATABASE_PRED")
     if server is None:
         raise ValueError(
-            "Les variables d'environnement SQL_SERVER_PRED ou SQL_SERVER sont manquantes."
+            "La variable d'environnement SQL_SERVER_PRED est manquante."
         )
     if database is None:
         raise ValueError(
-            "Les variables d'environnement SQL_DATABASE_PRED ou SQL_DATABASE sont manquantes."
+            "La variable d'environnement SQL_DATABASE_PRED est manquante."
         )
     return _build_engine(server, database)
 

--- a/secret.env.example
+++ b/secret.env.example
@@ -1,7 +1,11 @@
 SQL_USER=
 SQL_PASSWORD=
 SQL_DRIVER=
+
+# Connexion aux données historiques
 SQL_SERVER_HIST=
 SQL_DATABASE_HIST=
+
+# Connexion aux données de prédiction
 SQL_SERVER_PRED=
 SQL_DATABASE_PRED=


### PR DESCRIPTION
## Summary
- remove SQL_SERVER/SQL_DATABASE fallbacks from `get_engine_hist` and `get_engine_pred`
- document that generic connection names are no longer supported
- clarify `.env` example with dedicated variables for history and prediction

## Testing
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68aef4d14ac8832d81083311fd9dd9ed