### PR TITLE
Inspect table schema before building SELECT clauses

### DIFF
--- a/pages/1_Analyse_Prediction.py
+++ b/pages/1_Analyse_Prediction.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import plotly.express as px
 import streamlit as st
 
@@ -34,36 +35,42 @@ def main() -> None:
         st.warning("Aucune donnée disponible.")
         return
 
-    status_counts = df["stock_status"].value_counts()
+    status_counts = (
+        df["stock_status"].value_counts() if "stock_status" in df else pd.Series()
+    )
     col1, col2, col3 = st.columns(3)
     col1.metric("OK", int(status_counts.get("OK", 0)))
     col2.metric("Rupture", int(status_counts.get("RUPTURE", 0)))
     col3.metric("Critique", int(status_counts.get("CRITIQUE", 0)))
 
-    brand_crit = (
-        df.groupby("tyre_brand")["criticality_score"].mean().reset_index()
-    )
-    crit_fig = px.bar(
-        brand_crit,
-        x="tyre_brand",
-        y="criticality_score",
-        title="Criticité moyenne par marque",
-        color_discrete_sequence=ASSOCIATED_COLORS,
-    )
-    st.plotly_chart(crit_fig, use_container_width=True)
+    if "criticality_score" in df:
+        brand_crit = (
+            df.groupby("tyre_brand")["criticality_score"].mean().reset_index()
+        )
+        crit_fig = px.bar(
+            brand_crit,
+            x="tyre_brand",
+            y="criticality_score",
+            title="Criticité moyenne par marque",
+            color_discrete_sequence=ASSOCIATED_COLORS,
+        )
+        st.plotly_chart(crit_fig, use_container_width=True)
 
-    evol_df = (
-        df.groupby(["date_key", "tyre_brand"])["stock_prediction"].sum().reset_index()
-    )
-    evol_fig = px.line(
-        evol_df,
-        x="date_key",
-        y="stock_prediction",
-        color="tyre_brand",
-        title="Évolution des prédictions de stock par marque",
-        color_discrete_sequence=ASSOCIATED_COLORS,
-    )
-    st.plotly_chart(evol_fig, use_container_width=True)
+    if "stock_prediction" in df:
+        evol_df = (
+            df.groupby(["date_key", "tyre_brand"])["stock_prediction"].sum().reset_index()
+        )
+        evol_fig = px.line(
+            evol_df,
+            x="date_key",
+            y="stock_prediction",
+            color="tyre_brand",
+            title="Évolution des prédictions de stock par marque",
+            color_discrete_sequence=ASSOCIATED_COLORS,
+        )
+        st.plotly_chart(evol_fig, use_container_width=True)
+    else:
+        st.info("Colonne 'stock_prediction' manquante.")
 
     display_dataframe(df)
     csv = df.to_csv(index=False).encode("utf-8")


### PR DESCRIPTION
## Summary
- inspect table schemas via `sqlalchemy.inspect(engine).get_columns` before building SELECT statements
- dynamically select available columns when loading historical or prediction data
- make dashboard pages tolerant of missing prediction columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef597ed50832d83807486131bf2fa