### PR TITLE
Improve error handling and add database diagnostics

### DIFF
--- a/tests/test_db_utils_diagnostics.py
+++ b/tests/test_db_utils_diagnostics.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import db_utils
+
+
+def test_run_diagnostics_success():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE t1 (id INTEGER PRIMARY KEY, name TEXT)"))
+        conn.execute(text("INSERT INTO t1 (name) VALUES ('a'), ('b')"))
+
+    report = db_utils.run_diagnostics(engine)
+    assert report["connected"] is True
+    assert "t1" in report["tables"]
+    assert report["tables"]["t1"] == ["id", "name"]
+    assert "t1" in report["samples"]
+    assert not report["samples"]["t1"].empty
+    assert report["errors"] == []
+
+
+def test_run_diagnostics_handles_query_error(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE t1 (id INTEGER)"))
+
+    def fake_read_sql(query, eng):
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(pd, "read_sql", fake_read_sql)
+    report = db_utils.run_diagnostics(engine)
+    assert report["connected"] is True
+    assert report["errors"]

--- a/tests/test_db_utils_error.py
+++ b/tests/test_db_utils_error.py
@@ -9,7 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import db_utils
 
 
-def test_load_hist_data_returns_empty_on_error(monkeypatch, caplog):
+def test_load_hist_data_raises_on_error(monkeypatch, caplog):
     def fake_read_sql(query, engine):
         raise SQLAlchemyError("boom")
 
@@ -18,12 +18,12 @@ def test_load_hist_data_returns_empty_on_error(monkeypatch, caplog):
     monkeypatch.setattr(pd, "read_sql", fake_read_sql)
 
     with caplog.at_level("ERROR"):
-        df = db_utils.load_hist_data()
-    assert df.empty
+        with pytest.raises(SQLAlchemyError):
+            db_utils.load_hist_data()
     assert "Erreur lors du chargement des données historiques" in caplog.text
 
 
-def test_load_prediction_data_returns_empty_on_error(monkeypatch, caplog):
+def test_load_prediction_data_raises_on_error(monkeypatch, caplog):
     def fake_read_sql(query, engine, params=None):
         raise SQLAlchemyError("boom")
 
@@ -32,12 +32,12 @@ def test_load_prediction_data_returns_empty_on_error(monkeypatch, caplog):
     monkeypatch.setattr(pd, "read_sql", fake_read_sql)
 
     with caplog.at_level("ERROR"):
-        df = db_utils.load_prediction_data("tbl")
-    assert df.empty
+        with pytest.raises(SQLAlchemyError):
+            db_utils.load_prediction_data("tbl")
     assert "Erreur lors du chargement des données de prédiction" in caplog.text
 
 
-def test_save_dataframe_to_table_handles_error(monkeypatch, caplog):
+def test_save_dataframe_to_table_raises_on_error(monkeypatch, caplog):
     df = pd.DataFrame({"a": [1]})
 
     def fake_to_sql(self, *args, **kwargs):
@@ -47,12 +47,12 @@ def test_save_dataframe_to_table_handles_error(monkeypatch, caplog):
     monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql)
 
     with caplog.at_level("ERROR"):
-        result = db_utils.save_dataframe_to_table(df, "tbl")
-    assert result.empty
+        with pytest.raises(SQLAlchemyError):
+            db_utils.save_dataframe_to_table(df, "tbl")
     assert "Erreur lors de l'enregistrement de la table" in caplog.text
 
 
-def test_find_hist_tables_handles_error(monkeypatch, caplog):
+def test_find_hist_tables_raises_on_error(monkeypatch, caplog):
     def fake_read_sql(query, engine):
         raise SQLAlchemyError("boom")
 
@@ -60,12 +60,12 @@ def test_find_hist_tables_handles_error(monkeypatch, caplog):
     monkeypatch.setattr(pd, "read_sql", fake_read_sql)
 
     with caplog.at_level("ERROR"):
-        tables = db_utils.find_hist_tables()
-    assert tables == []
+        with pytest.raises(SQLAlchemyError):
+            db_utils.find_hist_tables()
     assert "Erreur lors de la récupération des tables historiques" in caplog.text
 
 
-def test_find_pred_tables_handles_error(monkeypatch, caplog):
+def test_find_pred_tables_raises_on_error(monkeypatch, caplog):
     def fake_read_sql(query, engine):
         raise SQLAlchemyError("boom")
 
@@ -73,6 +73,6 @@ def test_find_pred_tables_handles_error(monkeypatch, caplog):
     monkeypatch.setattr(pd, "read_sql", fake_read_sql)
 
     with caplog.at_level("ERROR"):
-        tables = db_utils.find_pred_tables()
-    assert tables == []
+        with pytest.raises(SQLAlchemyError):
+            db_utils.find_pred_tables()
     assert "Erreur lors de la récupération des tables de prédiction" in caplog.text


### PR DESCRIPTION
## Summary
- use `logger.exception` and re-raise to avoid swallowing `SQLAlchemyError`
- add `run_diagnostics` utility to check connectivity, list tables, and sample data
- expand tests to cover new diagnostics and updated error semantics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef7d0f20c832d8693058736c9884c