### PR TITLE
Add table selection and schema display on pages

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -554,6 +554,36 @@ def prediction_table_exists(table_name: str) -> bool:
     return table_name in find_pred_tables()
 
 
+def get_table_columns(table_name: str, engine: Optional[Engine] = None) -> List[str]:
+    """Return the list of columns for the given table.
+
+    Parameters
+    ----------
+    table_name : str
+        Name of the table to inspect.
+    engine : Optional[Engine]
+        SQLAlchemy engine used for inspection. If ``None`` the prediction
+        database engine is used.
+
+    Returns
+    -------
+    List[str]
+        Names of columns present in the table.
+    """
+
+    validate_table_name(table_name)
+    engine = engine or get_engine_pred()
+    try:
+        inspector = inspect(engine)
+        cols_info = inspector.get_columns(table_name, schema="dbo")
+        return [c["name"] for c in cols_info]
+    except SQLAlchemyError:
+        logger.exception(
+            "Erreur lors de l'inspection de la table %s", table_name
+        )
+        raise
+
+
 def run_diagnostics(engine: Optional[Engine] = None) -> Dict[str, Any]:
     """Run connectivity and data checks on the target database.
 

--- a/pages/1_Analyse_Prediction.py
+++ b/pages/1_Analyse_Prediction.py
@@ -3,7 +3,11 @@ import plotly.express as px
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
-from db_utils import load_prediction_data, find_pred_tables
+from db_utils import (
+    load_prediction_data,
+    find_pred_tables,
+    get_table_columns,
+)
 from ui_utils import setup_sidebar_filters, display_dataframe
 
 
@@ -11,22 +15,40 @@ def main() -> None:
     st.set_page_config(page_title="Analyse prédictive", layout="wide")
 
     progress = st.progress(0)
-    tables = find_pred_tables()
+    try:
+        tables = find_pred_tables()
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de la récupération des tables : {e}")
+        return
     if not tables:
         st.warning("Aucune table de prédiction disponible.")
         return
-    table_name = tables[0]
+    table_name = st.selectbox("Table de prédiction", tables)
+    try:
+        cols = get_table_columns(table_name)
+        st.caption("Colonnes disponibles : " + ", ".join(cols))
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de l'inspection du schéma : {e}")
+        return
 
-    df_full = load_prediction_data(table_name)
+    try:
+        df_full = load_prediction_data(table_name)
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données : {e}")
+        return
     progress.progress(50)
 
     filters = setup_sidebar_filters(df_full)
-    df = load_prediction_data(
-        table_name,
-        brands=filters["brands"],
-        seasons=filters["seasons"],
-        sizes=filters["sizes"],
-    )
+    try:
+        df = load_prediction_data(
+            table_name,
+            brands=filters["brands"],
+            seasons=filters["seasons"],
+            sizes=filters["sizes"],
+        )
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données filtrées : {e}")
+        return
     progress.progress(100)
 
     st.title("Analyse prédictive")

--- a/pages/1_Gestion_Ruptures.py
+++ b/pages/1_Gestion_Ruptures.py
@@ -1,7 +1,11 @@
 import plotly.express as px
 import streamlit as st
 
-from db_utils import load_prediction_data, find_pred_tables
+from db_utils import (
+    load_prediction_data,
+    find_pred_tables,
+    get_table_columns,
+)
 from ui_utils import setup_sidebar_filters, display_dataframe
 
 
@@ -9,22 +13,40 @@ def main() -> None:
     st.set_page_config(page_title="Gestion des ruptures", layout="wide")
 
     progress = st.progress(0)
-    tables = find_pred_tables()
+    try:
+        tables = find_pred_tables()
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de la récupération des tables : {e}")
+        return
     if not tables:
         st.warning("Aucune table de prédiction disponible.")
         return
-    table_name = tables[0]
+    table_name = st.selectbox("Table de prédiction", tables)
+    try:
+        cols = get_table_columns(table_name)
+        st.caption("Colonnes disponibles : " + ", ".join(cols))
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de l'inspection du schéma : {e}")
+        return
 
-    df_full = load_prediction_data(table_name)
+    try:
+        df_full = load_prediction_data(table_name)
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données : {e}")
+        return
     progress.progress(50)
 
     filters = setup_sidebar_filters(df_full)
-    df = load_prediction_data(
-        table_name,
-        brands=filters["brands"],
-        seasons=filters["seasons"],
-        sizes=filters["sizes"],
-    )
+    try:
+        df = load_prediction_data(
+            table_name,
+            brands=filters["brands"],
+            seasons=filters["seasons"],
+            sizes=filters["sizes"],
+        )
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données filtrées : {e}")
+        return
     progress.progress(100)
 
     st.title("Gestion des ruptures")

--- a/pages/2_Analyse_Prix.py
+++ b/pages/2_Analyse_Prix.py
@@ -3,7 +3,11 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
-from db_utils import load_prediction_data, find_pred_tables
+from db_utils import (
+    load_prediction_data,
+    find_pred_tables,
+    get_table_columns,
+)
 from ui_utils import setup_sidebar_filters, display_dataframe
 
 
@@ -11,22 +15,40 @@ def main() -> None:
     st.set_page_config(page_title="Analyse des prix", layout="wide")
 
     progress = st.progress(0)
-    tables = find_pred_tables()
+    try:
+        tables = find_pred_tables()
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de la récupération des tables : {e}")
+        return
     if not tables:
         st.warning("Aucune table de prédiction disponible.")
         return
-    table_name = tables[0]
+    table_name = st.selectbox("Table de prédiction", tables)
+    try:
+        cols = get_table_columns(table_name)
+        st.caption("Colonnes disponibles : " + ", ".join(cols))
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de l'inspection du schéma : {e}")
+        return
 
-    df_full = load_prediction_data(table_name)
+    try:
+        df_full = load_prediction_data(table_name)
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données : {e}")
+        return
     progress.progress(50)
 
     filters = setup_sidebar_filters(df_full)
-    df = load_prediction_data(
-        table_name,
-        brands=filters["brands"],
-        seasons=filters["seasons"],
-        sizes=filters["sizes"],
-    )
+    try:
+        df = load_prediction_data(
+            table_name,
+            brands=filters["brands"],
+            seasons=filters["seasons"],
+            sizes=filters["sizes"],
+        )
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données filtrées : {e}")
+        return
     progress.progress(100)
 
     st.title("Analyse des prix")

--- a/pages/3_Volatilite_Risques.py
+++ b/pages/3_Volatilite_Risques.py
@@ -2,7 +2,11 @@ import plotly.express as px
 import streamlit as st
 
 from constants import ASSOCIATED_COLORS
-from db_utils import load_prediction_data, find_pred_tables
+from db_utils import (
+    load_prediction_data,
+    find_pred_tables,
+    get_table_columns,
+)
 from ui_utils import setup_sidebar_filters, display_dataframe
 
 
@@ -10,22 +14,40 @@ def main() -> None:
     st.set_page_config(page_title="Volatilité & Risques", layout="wide")
 
     progress = st.progress(0)
-    tables = find_pred_tables()
+    try:
+        tables = find_pred_tables()
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de la récupération des tables : {e}")
+        return
     if not tables:
         st.warning("Aucune table de prédiction disponible.")
         return
-    table_name = tables[0]
+    table_name = st.selectbox("Table de prédiction", tables)
+    try:
+        cols = get_table_columns(table_name)
+        st.caption("Colonnes disponibles : " + ", ".join(cols))
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de l'inspection du schéma : {e}")
+        return
 
-    df_full = load_prediction_data(table_name)
+    try:
+        df_full = load_prediction_data(table_name)
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données : {e}")
+        return
     progress.progress(50)
 
     filters = setup_sidebar_filters(df_full)
-    df = load_prediction_data(
-        table_name,
-        brands=filters["brands"],
-        seasons=filters["seasons"],
-        sizes=filters["sizes"],
-    )
+    try:
+        df = load_prediction_data(
+            table_name,
+            brands=filters["brands"],
+            seasons=filters["seasons"],
+            sizes=filters["sizes"],
+        )
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données filtrées : {e}")
+        return
     progress.progress(100)
 
     st.title("Volatilité & Risques")

--- a/tests/test_db_utils_tables.py
+++ b/tests/test_db_utils_tables.py
@@ -155,6 +155,17 @@ def test_load_prediction_data_filters(monkeypatch):
     assert isinstance(df.loc[0, "last_safe_order_date"], pd.Timestamp)
 
 
+def test_get_table_columns(monkeypatch):
+    class DummyInspector:
+        def get_columns(self, tbl, schema=None):
+            return [{"name": "c1"}, {"name": "c2"}]
+
+    monkeypatch.setattr(db_utils, "get_engine_pred", lambda: object())
+    monkeypatch.setattr(db_utils, "inspect", lambda engine: DummyInspector())
+
+    assert db_utils.get_table_columns("tbl") == ["c1", "c2"]
+
+
 if __name__ == "__main__":
     import pytest
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- add utility to inspect table schema
- allow selecting prediction table from dropdown on analysis pages and show available columns
- surface errors from database operations in Streamlit UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef9646958832dbac06332a3e0c6c0