### PR TITLE
Refine test suite for table validation and diagnostics

### DIFF
--- a/tests/test_db_utils_diagnostics.py
+++ b/tests/test_db_utils_diagnostics.py
@@ -37,3 +37,15 @@ def test_run_diagnostics_handles_query_error(monkeypatch):
     report = db_utils.run_diagnostics(engine)
     assert report["connected"] is True
     assert report["errors"]
+
+
+def test_run_diagnostics_handles_connection_error(monkeypatch):
+    class FailingEngine:
+        def connect(self):
+            raise SQLAlchemyError("boom")
+
+        dialect = type("d", (), {"name": "sqlite"})()
+
+    report = db_utils.run_diagnostics(FailingEngine())
+    assert report["connected"] is False
+    assert report["errors"]

--- a/tests/test_db_utils_validation.py
+++ b/tests/test_db_utils_validation.py
@@ -8,15 +8,35 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import db_utils
 
 
-def test_load_prediction_data_invalid_table_name():
-    with pytest.raises(ValueError):
-        db_utils.load_prediction_data("bad;table")
+def test_validate_table_name_valid(monkeypatch):
+    """Valid table names pass regex and existence checks."""
+
+    class DummyInspector:
+        def has_table(self, table, schema):
+            return True
+
+    monkeypatch.setattr(db_utils, "inspect", lambda engine: DummyInspector())
+    db_utils.validate_table_name("valid_table_123", engine=object())
 
 
-def test_load_prediction_data_missing_table(monkeypatch):
-    monkeypatch.setattr(db_utils, "prediction_table_exists", lambda name: False)
+@pytest.mark.parametrize("name", ["bad;name", "bad name", "name$", ""]) 
+def test_validate_table_name_invalid(name):
+    """Invalid table names raise ``ValueError`` due to regex check."""
+
     with pytest.raises(ValueError):
-        db_utils.load_prediction_data("pred_missing")
+        db_utils.validate_table_name(name)
+
+
+def test_validate_table_name_missing_table(monkeypatch):
+    """Valid name but missing table raises ``ValueError`` when engine is provided."""
+
+    class DummyInspector:
+        def has_table(self, table, schema):
+            return False
+
+    monkeypatch.setattr(db_utils, "inspect", lambda engine: DummyInspector())
+    with pytest.raises(ValueError):
+        db_utils.validate_table_name("missing_table", engine=object())
 
 
 def test_save_dataframe_to_table_invalid_name():


### PR DESCRIPTION
## Summary
- replace whitelist table checks with regex-based validation tests
- verify dynamic table classification is case-insensitive via mocked DB responses
- ensure diagnostics report connection failures correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aefa239dc8832da86864f6a8b0f7ec