### PR TITLE
feat: add comparative analysis page

### DIFF
--- a/pages/1_Analyse_Comparative.py
+++ b/pages/1_Analyse_Comparative.py
@@ -1,0 +1,191 @@
+import pandas as pd
+import plotly.graph_objects as go
+import plotly.express as px
+import streamlit as st
+
+from constants import ASSOCIATED_COLORS
+from db_utils import (
+    load_hist_data,
+    load_prediction_data,
+    find_pred_tables,
+    get_table_columns,
+)
+from ui_utils import (
+    setup_prediction_comparison_filters,
+    display_dataframe,
+)
+
+
+def plot_historical_vs_multi_predictions(
+    hist_df: pd.DataFrame, pred_df: pd.DataFrame
+) -> None:
+    """Plot historical quantities against available prediction series."""
+    fig = go.Figure()
+    if {"date_key", "Sum_stock_quantity"}.issubset(hist_df.columns):
+        fig.add_trace(
+            go.Scatter(
+                x=hist_df["date_key"],
+                y=hist_df["Sum_stock_quantity"],
+                mode="lines",
+                name="Historique",
+            )
+        )
+    for col in pred_df.columns:
+        if col.startswith("stock_prediction"):
+            fig.add_trace(
+                go.Scatter(
+                    x=pred_df["date_key"],
+                    y=pred_df[col],
+                    mode="lines",
+                    name=col,
+                )
+            )
+    fig.update_layout(
+        title="Historique vs prédictions",
+        colorway=ASSOCIATED_COLORS,
+        xaxis_title="Date",
+        yaxis_title="Volume",
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def analyze_prediction_accuracy_by_week(
+    hist_df: pd.DataFrame, pred_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Compute weekly accuracy between historical and predicted values."""
+    if not (
+        {"date_key", "Sum_stock_quantity"}.issubset(hist_df.columns)
+        and {"date_key", "stock_prediction"}.issubset(pred_df.columns)
+    ):
+        return pd.DataFrame()
+    merged = pred_df.merge(
+        hist_df[["date_key", "Sum_stock_quantity"]],
+        on="date_key",
+        how="left",
+    )
+    merged["abs_error"] = (
+        merged["stock_prediction"] - merged["Sum_stock_quantity"]
+    ).abs()
+    merged["week"] = pd.to_datetime(merged["date_key"]).dt.to_period("W").apply(
+        lambda r: r.start_time
+    )
+    weekly = (
+        merged.groupby("week")
+        .apply(
+            lambda d: 1
+            - d["abs_error"].sum() / d["Sum_stock_quantity"].sum()
+            if d["Sum_stock_quantity"].sum()
+            else 0
+        )
+        .reset_index(name="accuracy")
+    )
+    return weekly
+
+
+def plot_accuracy_evolution(acc_df: pd.DataFrame) -> None:
+    """Display the evolution of prediction accuracy."""
+    if acc_df.empty:
+        st.info("Aucune donnée de précision disponible.")
+        return
+    fig = px.line(
+        acc_df,
+        x="week",
+        y="accuracy",
+        markers=True,
+        title="Évolution de la précision",
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def prepare_export_data(
+    hist_df: pd.DataFrame, pred_df: pd.DataFrame, acc_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Merge historical, prediction and accuracy data for export."""
+    export_df = pred_df.merge(
+        hist_df,
+        on=["date_key", "tyre_brand", "tyre_season_french", "tyre_fullsize"],
+        how="left",
+        suffixes=("_pred", "_hist"),
+    )
+    if not acc_df.empty:
+        export_df["week"] = pd.to_datetime(export_df["date_key"]).dt.to_period("W").apply(
+            lambda r: r.start_time
+        )
+        export_df = export_df.merge(acc_df, on="week", how="left")
+    return export_df
+
+
+def main() -> None:
+    st.set_page_config(page_title="Analyse comparative", layout="wide")
+
+    progress = st.progress(0)
+    try:
+        tables = find_pred_tables()
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de la récupération des tables : {e}")
+        return
+    if not tables:
+        st.warning("Aucune table de prédiction disponible.")
+        return
+    table_name = st.selectbox("Table de prédiction", tables)
+    try:
+        cols = get_table_columns(table_name)
+        st.caption("Colonnes disponibles : " + ", ".join(cols))
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors de l'inspection du schéma : {e}")
+        return
+
+    try:
+        df_full = load_prediction_data(table_name)
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données : {e}")
+        return
+    progress.progress(50)
+
+    filters = setup_prediction_comparison_filters(df_full)
+    try:
+        df_pred = load_prediction_data(
+            table_name,
+            brands=filters["brands"],
+            seasons=filters["seasons"],
+            sizes=filters["sizes"],
+            start_date=filters["start_date"],
+            end_date=filters["end_date"],
+        )
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données de prédiction : {e}")
+        return
+
+    try:
+        df_hist = load_hist_data(
+            brands=filters["brands"],
+            seasons=filters["seasons"],
+            sizes=filters["sizes"],
+            start_date=filters["start_date"],
+            end_date=filters["end_date"],
+        )
+    except Exception as e:  # pragma: no cover - Streamlit runtime
+        st.error(f"Erreur lors du chargement des données historiques : {e}")
+        return
+    progress.progress(100)
+
+    st.title("Analyse comparative")
+
+    if df_pred.empty or df_hist.empty:
+        st.warning("Aucune donnée disponible.")
+        return
+
+    plot_historical_vs_multi_predictions(df_hist, df_pred)
+    acc_df = analyze_prediction_accuracy_by_week(df_hist, df_pred)
+    plot_accuracy_evolution(acc_df)
+
+    export_df = prepare_export_data(df_hist, df_pred, acc_df)
+    st.subheader("Données combinées")
+    display_dataframe(export_df)
+    csv = export_df.to_csv(index=False).encode("utf-8")
+    st.download_button("Exporter CSV", csv, "analyse_comparative.csv", "text/csv")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_ui_utils.py
+++ b/tests/test_ui_utils.py
@@ -3,10 +3,14 @@ from pathlib import Path
 import types
 
 import streamlit as st
+import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import db_utils
-from ui_utils import setup_sidebar_filters
+from ui_utils import (
+    setup_sidebar_filters,
+    setup_prediction_comparison_filters,
+)
 
 
 def test_setup_sidebar_filters_discovers_platforms(monkeypatch):
@@ -34,3 +38,24 @@ def test_setup_sidebar_filters_discovers_platforms(monkeypatch):
     filters = setup_sidebar_filters()
     assert captured["platform_options"] == ["amz", "ebay"]
     assert filters["platform"] == "amz"
+
+
+def test_setup_prediction_comparison_filters(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "tyre_brand": ["A"],
+            "tyre_season_french": ["Été"],
+            "tyre_fullsize": ["195"],
+        }
+    )
+
+    dummy_sidebar = types.SimpleNamespace(
+        date_input=lambda label, value=None: value,
+        multiselect=lambda label, options, default=None: default or [],
+    )
+    monkeypatch.setattr(st, "sidebar", dummy_sidebar)
+
+    filters = setup_prediction_comparison_filters(df)
+    assert filters["brands"] == ["A"]
+    assert filters["seasons"] == ["Été"]
+    assert filters["sizes"] == ["195"]

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -91,6 +91,64 @@ def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:
     }
 
 
+def setup_prediction_comparison_filters(
+    df: Optional[pd.DataFrame] = None,
+) -> Dict[str, Any]:
+    """Render sidebar filters for the comparative analysis page.
+
+    Parameters
+    ----------
+    df : Optional[pandas.DataFrame]
+        DataFrame used to populate brand, season and size options if
+        provided. Only the presence of relevant columns is checked.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing the selected filter values including a
+        date range.
+    """
+
+    default_start = datetime.date.today() - datetime.timedelta(days=30)
+    default_end = datetime.date.today()
+    start_date, end_date = st.sidebar.date_input(
+        "Période", (default_start, default_end)
+    )
+
+    brand_options: List[str] = []
+    season_options: List[str] = []
+    size_options: List[str] = []
+
+    if df is not None:
+        if "tyre_brand" in df:
+            brand_options = sorted(df["tyre_brand"].dropna().unique().tolist())
+        if "tyre_season_french" in df:
+            season_options = sorted(
+                df["tyre_season_french"].dropna().unique().tolist()
+            )
+        if "tyre_fullsize" in df:
+            size_options = sorted(df["tyre_fullsize"].dropna().unique().tolist())
+
+    brands = st.sidebar.multiselect("Marques", brand_options, default=brand_options)
+    seasons = st.sidebar.multiselect("Saisons", season_options, default=season_options)
+    sizes = st.sidebar.multiselect("Tailles", size_options, default=size_options)
+
+    brands = sanitize_list(brands)
+    seasons = sanitize_list(seasons)
+    sizes = sanitize_list(sizes)
+
+    start_ts = pd.to_datetime(start_date)
+    end_ts = pd.to_datetime(end_date)
+
+    return {
+        "start_date": start_ts,
+        "end_date": end_ts,
+        "brands": brands,
+        "seasons": seasons,
+        "sizes": sizes,
+    }
+
+
 def display_dataframe(df: pd.DataFrame, rows_per_page: int = 1000) -> None:
     """Display a DataFrame with pagination when it exceeds 10k rows.
 


### PR DESCRIPTION
## Summary
- add comparative analysis page with multi-prediction plotting and accuracy review
- introduce `setup_prediction_comparison_filters` for targeted filtering
- include export preparation and coverage tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aefea39994832d9b8094e9d05d0f65