### PR TITLE
feat: add WYZ color palette

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,3 +6,13 @@ ASSOCIATED_COLORS = [
     "#82b86a",
     "#45b49d",
 ]
+
+# Brand color information for WYZ theme
+WYZ_COLORS = {
+    "primary": "#7fbfdc",
+    "secondary": "#6ba6b6",
+    "background": "#ffffff",
+    "text": "#000000",
+    "palette": ASSOCIATED_COLORS,
+}
+


### PR DESCRIPTION
## Summary
- add WYZ brand color configuration with primary, secondary, background, text and palette entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af0008b4b0832d909156515af9f71c