### PR TITLE
feat: add utilities for weekly prediction tables

### DIFF
--- a/tests/test_prediction_weeks.py
+++ b/tests/test_prediction_weeks.py
@@ -1,0 +1,77 @@
+import pandas as pd
+import db_utils
+
+
+def test_discover_prediction_weeks(monkeypatch):
+    monkeypatch.setattr(
+        db_utils,
+        "find_pred_tables",
+        lambda: [
+            "pred_amz_man_20240101",
+            "pred_amz_dis_20240101",
+            "pred_amz_man_20240108",
+            "pred_ebay_man_20240101",
+        ],
+    )
+    weeks = db_utils.discover_prediction_weeks("amz")
+    assert weeks == [
+        "01/01/2024 - Semaine 1",
+        "08/01/2024 - Semaine 2",
+    ]
+
+
+def test_load_multi_week_predictions(monkeypatch):
+    monkeypatch.setattr(
+        db_utils,
+        "find_pred_tables",
+        lambda: [
+            "pred_amz_man_20240101",
+            "pred_amz_man_20240108",
+            "pred_amz_dis_20240101",
+        ],
+    )
+    calls = []
+
+    def fake_load_prediction_data(
+        table_name,
+        *,
+        brands=None,
+        seasons=None,
+        sizes=None,
+        start_date=None,
+        end_date=None,
+    ):
+        calls.append(
+            {
+                "table_name": table_name,
+                "brands": brands,
+                "seasons": seasons,
+                "sizes": sizes,
+                "start_date": start_date,
+                "end_date": end_date,
+            }
+        )
+        return pd.DataFrame({"table": [table_name]})
+
+    monkeypatch.setattr(db_utils, "load_prediction_data", fake_load_prediction_data)
+
+    filters = {
+        "brands": ["MICHELIN"],
+        "seasons": ["ETE"],
+        "sizes": ["205/55R16"],
+        "start_date": None,
+        "end_date": None,
+    }
+    selected = [
+        "01/01/2024 - Semaine 1",
+        "08/01/2024 - Semaine 2",
+    ]
+    result = db_utils.load_multi_week_predictions("amz", "man", selected, filters)
+
+    assert set(result.keys()) == set(selected)
+    assert calls[0]["brands"] == ["MICHELIN"]
+    assert calls[0]["seasons"] == ["ETE"]
+    assert calls[0]["sizes"] == ["205/55R16"]
+    assert calls[0]["start_date"] is None
+    assert calls[0]["end_date"] is None
+    assert calls[1]["table_name"] == "pred_amz_man_20240108"


### PR DESCRIPTION
## Summary
- support week label discovery from prediction table names
- load predictions for multiple weeks with explicit filter forwarding
- test weekly prediction helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af00abd514832d8ed2f465ef1e24f8