### PR TITLE
Add confidence-aware prediction aggregation and color utilities

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -654,6 +654,34 @@ def load_multi_week_predictions(
     return result
 
 
+def aggregate_predictions(df: pd.DataFrame, show_confidence: bool = False) -> pd.DataFrame:
+    """Aggregate prediction values per date and brand.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing prediction data with at least ``date_key``,
+        ``tyre_brand`` and ``stock_prediction`` columns.
+    show_confidence : bool, default ``False``
+        Include ``ic_stock_plus`` and ``ic_stock_minus`` columns in the
+        aggregation if they are present in ``df`` and ``show_confidence`` is
+        ``True``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Aggregated DataFrame.
+    """
+
+    agg_dict = {"stock_prediction": "sum"}
+    if show_confidence and {"ic_stock_plus", "ic_stock_minus"}.issubset(df.columns):
+        agg_dict.update({"ic_stock_plus": "sum", "ic_stock_minus": "sum"})
+    return (
+        df.groupby(["date_key", "tyre_brand"], as_index=False)
+        .agg(agg_dict)
+    )
+
+
 def get_table_columns(table_name: str, engine: Optional[Engine] = None) -> List[str]:
     """Return the list of columns for the given table.
 

--- a/pages/2_Analyse_Prix.py
+++ b/pages/2_Analyse_Prix.py
@@ -1,6 +1,7 @@
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
+from typing import Tuple
 
 from constants import ASSOCIATED_COLORS
 from db_utils import (
@@ -9,6 +10,17 @@ from db_utils import (
     get_table_columns,
 )
 from ui_utils import setup_sidebar_filters, display_dataframe
+
+
+def hex_to_rgb(color: str) -> Tuple[int, int, int]:
+    """Convert HEX color (e.g. ``"#ff00aa"``) to an RGB tuple."""
+    color = color.lstrip("#")
+    if len(color) != 6:
+        raise ValueError("Invalid HEX color")
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+    return r, g, b
 
 
 def main() -> None:
@@ -68,6 +80,7 @@ def main() -> None:
         )
     )
     if "ic_price_plus" in price_df and "ic_price_minus" in price_df:
+        r, g, b = hex_to_rgb(ASSOCIATED_COLORS[0])
         fig.add_trace(
             go.Scatter(
                 x=price_df["date_key"],
@@ -85,7 +98,7 @@ def main() -> None:
                 mode="lines",
                 line=dict(width=0),
                 fill="tonexty",
-                fillcolor="rgba(127,191,220,0.2)",
+                fillcolor=f"rgba({r},{g},{b},0.2)",
                 name="Intervalle de confiance",
             )
         )

--- a/tests/test_aggregate_predictions.py
+++ b/tests/test_aggregate_predictions.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import db_utils
+
+
+def test_aggregate_predictions_missing_confidence_columns():
+    df = pd.DataFrame(
+        {
+            "date_key": pd.to_datetime(["2024-01-01", "2024-01-01"]),
+            "tyre_brand": ["A", "A"],
+            "stock_prediction": [1.0, 2.0],
+        }
+    )
+    result = db_utils.aggregate_predictions(df, show_confidence=True)
+    assert list(result.columns) == ["date_key", "tyre_brand", "stock_prediction"]
+    assert result.loc[0, "stock_prediction"] == 3.0
+
+
+def test_aggregate_predictions_with_confidence_columns():
+    df = pd.DataFrame(
+        {
+            "date_key": pd.to_datetime(["2024-01-01", "2024-01-01"]),
+            "tyre_brand": ["A", "A"],
+            "stock_prediction": [1.0, 2.0],
+            "ic_stock_plus": [1.1, 2.1],
+            "ic_stock_minus": [0.9, 1.9],
+        }
+    )
+    result = db_utils.aggregate_predictions(df, show_confidence=True)
+    assert "ic_stock_plus" in result.columns
+    assert "ic_stock_minus" in result.columns
+    assert result.loc[0, "ic_stock_plus"] == pytest.approx(3.2)
+    assert result.loc[0, "ic_stock_minus"] == pytest.approx(2.8)


### PR DESCRIPTION
## Summary
- add hex_to_rgb helper and use it for price confidence band coloring
- aggregate stock predictions conditionally on confidence columns
- test prediction aggregation with and without confidence intervals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0705cb84832d9026408ac592115d