### PR TITLE
Use central platform discovery in UI filters

### DIFF
--- a/tests/test_ui_utils.py
+++ b/tests/test_ui_utils.py
@@ -16,10 +16,9 @@ from ui_utils import (
 def test_setup_sidebar_filters_discovers_platforms(monkeypatch):
     monkeypatch.setattr(
         db_utils,
-        "find_hist_tables",
-        lambda: ["fullsize_stock_hist_amz", "fullsize_stock_hist_ebay"],
+        "discover_platforms",
+        lambda: {"amz": ["man"], "ebay": ["dis"]},
     )
-    monkeypatch.setattr(db_utils, "find_pred_tables", lambda: ["pred_amz"])
 
     captured = {}
 

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -9,23 +9,6 @@ import db_utils
 from input_utils import sanitize_input, sanitize_list
 
 
-def _discover_platforms() -> List[str]:
-    """Discover platform names from available database tables.
-
-    Returns
-    -------
-    List[str]
-        Sorted unique platform names extracted from historical and
-        prediction table names.
-    """
-    tables = db_utils.find_hist_tables() + db_utils.find_pred_tables()
-    platforms = {
-        tbl.replace("fullsize_stock_hist_", "").replace("pred_", "")
-        for tbl in tables
-    }
-    return sorted(platforms)
-
-
 def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:
     """Render common sidebar filters and return selected values.
 
@@ -41,7 +24,7 @@ def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:
     Dict[str, Any]
         Dictionary containing the selected filter values.
     """
-    platforms = _discover_platforms()
+    platforms = sorted(db_utils.discover_platforms().keys())
     platform = (
         st.sidebar.selectbox("Plateforme", platforms)
         if platforms


### PR DESCRIPTION
## Summary
- pull platform options from `db_utils.discover_platforms` to avoid duplication
- update tests to mock centralized discovery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b00af3c62c832d8dd781541ddaad10