### PR TITLE
Add hex color helper for reusable RGBA support

### DIFF
--- a/pages/1_Analyse_Prediction.py
+++ b/pages/1_Analyse_Prediction.py
@@ -2,7 +2,6 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-from typing import Tuple
 
 from constants import ASSOCIATED_COLORS
 from db_utils import (
@@ -11,18 +10,7 @@ from db_utils import (
     get_table_columns,
     aggregate_predictions,
 )
-from ui_utils import setup_sidebar_filters, display_dataframe
-
-
-def hex_to_rgb(color: str) -> Tuple[int, int, int]:
-    """Convert HEX color to an RGB tuple."""
-    color = color.lstrip("#")
-    if len(color) != 6:
-        raise ValueError("Invalid HEX color")
-    r = int(color[0:2], 16)
-    g = int(color[2:4], 16)
-    b = int(color[4:6], 16)
-    return r, g, b
+from ui_utils import setup_sidebar_filters, display_dataframe, hex_to_rgb
 
 
 def main() -> None:

--- a/pages/2_Analyse_Prix.py
+++ b/pages/2_Analyse_Prix.py
@@ -1,26 +1,13 @@
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-from typing import Tuple
-
 from constants import ASSOCIATED_COLORS
 from db_utils import (
     load_prediction_data,
     find_pred_tables,
     get_table_columns,
 )
-from ui_utils import setup_sidebar_filters, display_dataframe
-
-
-def hex_to_rgb(color: str) -> Tuple[int, int, int]:
-    """Convert HEX color (e.g. ``"#ff00aa"``) to an RGB tuple."""
-    color = color.lstrip("#")
-    if len(color) != 6:
-        raise ValueError("Invalid HEX color")
-    r = int(color[0:2], 16)
-    g = int(color[2:4], 16)
-    b = int(color[4:6], 16)
-    return r, g, b
+from ui_utils import setup_sidebar_filters, display_dataframe, hex_to_rgb
 
 
 def main() -> None:

--- a/tests/test_ui_utils.py
+++ b/tests/test_ui_utils.py
@@ -4,12 +4,14 @@ import types
 
 import streamlit as st
 import pandas as pd
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import db_utils
 from ui_utils import (
     setup_sidebar_filters,
     setup_prediction_comparison_filters,
+    hex_to_rgb,
 )
 
 
@@ -58,3 +60,13 @@ def test_setup_prediction_comparison_filters(monkeypatch):
     assert filters["brands"] == ["A"]
     assert filters["seasons"] == ["Été"]
     assert filters["sizes"] == ["195"]
+
+
+def test_hex_to_rgb_valid():
+    assert hex_to_rgb("#ffffff") == (255, 255, 255)
+    assert hex_to_rgb("#000000") == (0, 0, 0)
+
+
+def test_hex_to_rgb_invalid():
+    with pytest.raises(ValueError):
+        hex_to_rgb("zzz")

--- a/ui_utils.py
+++ b/ui_utils.py
@@ -1,12 +1,23 @@
 import datetime
 import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import streamlit as st
 
 import db_utils
 from input_utils import sanitize_input, sanitize_list
+
+
+def hex_to_rgb(color: str) -> Tuple[int, int, int]:
+    """Convert HEX color (e.g. ``"#ff00aa"``) to an RGB tuple."""
+    color = color.lstrip("#")
+    if len(color) != 6:
+        raise ValueError("Invalid HEX color")
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+    return r, g, b
 
 
 def setup_sidebar_filters(df: Optional[object] = None) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add `ui_utils.hex_to_rgb` helper
- reuse helper for RGBA values in prediction, price, and comparative plots
- cover color helper with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b01c87222c832d957732fee48ebc43