### PR TITLE
Handle default week selection with fewer available weeks

### DIFF
--- a/tests/test_prediction_weeks.py
+++ b/tests/test_prediction_weeks.py
@@ -78,3 +78,29 @@ def test_load_multi_week_predictions(monkeypatch):
     assert calls[0]["start_date"] is None
     assert calls[0]["end_date"] is None
     assert calls[1]["table_name"] == "pred_amz_man_20240109"
+
+
+def test_load_multi_week_predictions_default_under_four(monkeypatch):
+    monkeypatch.setattr(
+        db_utils,
+        "find_pred_tables",
+        lambda: [
+            "pred_amz_man_20240102",
+            "pred_amz_man_20240109",
+            "pred_amz_man_20240116",
+        ],
+    )
+
+    def fake_load_prediction_data(table_name, **kwargs):
+        return pd.DataFrame({"table": [table_name]})
+
+    monkeypatch.setattr(db_utils, "load_prediction_data", fake_load_prediction_data)
+
+    result = db_utils.load_multi_week_predictions("amz", "man", filters={})
+
+    expected_keys = [
+        "02/01/2024 - Semaine 1",
+        "09/01/2024 - Semaine 2",
+        "16/01/2024 - Semaine 3",
+    ]
+    assert list(result.keys()) == expected_keys


### PR DESCRIPTION
## Summary
- ensure `load_multi_week_predictions` falls back to last available weeks when fewer than four exist
- cover default selection logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b020aad59c832db665911c92b992d5