### PR TITLE
Sort accuracy evolution weeks chronologically

### DIFF
--- a/pages/1_Analyse_Comparative.py
+++ b/pages/1_Analyse_Comparative.py
@@ -122,8 +122,18 @@ def plot_accuracy_evolution(acc_df: pd.DataFrame) -> None:
     if acc_df.empty:
         st.info("Aucune donnée de précision disponible.")
         return
+    # ``week`` can contain localized labels (e.g. ``"01/01/2024 - Semaine 1"``).
+    # Convert them back to ``datetime`` for proper chronological sorting,
+    # then plot using the original labels to preserve the display format.
+    df = acc_df.copy()
+    df["_week_dt"] = pd.to_datetime(
+        df["week"].astype(str).str.split(" - ").str[0],
+        errors="coerce",
+        dayfirst=True,
+    )
+    df = df.sort_values("_week_dt")
     fig = px.line(
-        acc_df,
+        df,
         x="week",
         y="accuracy",
         markers=True,

--- a/tests/test_plot_accuracy_evolution.py
+++ b/tests/test_plot_accuracy_evolution.py
@@ -1,0 +1,46 @@
+import importlib.util
+from pathlib import Path
+import locale
+import pandas as pd
+
+# Dynamically load the module since the filename starts with a digit
+spec = importlib.util.spec_from_file_location(
+    "analyse_module", Path("pages") / "1_Analyse_Comparative.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+plot_accuracy_evolution = module.plot_accuracy_evolution
+
+
+def test_plot_accuracy_evolution_chronological(monkeypatch):
+    # Ensure a non-French locale is active
+    previous_locale = locale.setlocale(locale.LC_TIME)
+    locale.setlocale(locale.LC_TIME, "C")
+    try:
+        acc_df = pd.DataFrame(
+            {
+                "week": [
+                    "15/01/2024 - Semaine 3",
+                    "01/01/2024 - Semaine 1",
+                    "08/01/2024 - Semaine 2",
+                ],
+                "accuracy": [0.9, 0.8, 0.85],
+            }
+        )
+        captured = {}
+
+        def fake_plotly_chart(fig, use_container_width=True):
+            captured["fig"] = fig
+
+        monkeypatch.setattr(module.st, "plotly_chart", fake_plotly_chart)
+        plot_accuracy_evolution(acc_df)
+    finally:
+        locale.setlocale(locale.LC_TIME, previous_locale)
+
+    x_vals = list(captured["fig"].data[0].x)
+    assert x_vals == [
+        "01/01/2024 - Semaine 1",
+        "08/01/2024 - Semaine 2",
+        "15/01/2024 - Semaine 3",
+    ]


### PR DESCRIPTION
## Summary
- Convert localized week labels to datetime for sorting in `plot_accuracy_evolution`
- Add unit test ensuring weeks plot chronologically even with non-French locale

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0618d0e34832d94964fd4c1f7874b