### PR TITLE
Add helper for activity suffix mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ charge ; vous devez définir explicitement les quatre variables ci-dessus.
 
 Les tables historiques suivent le motif `fullsize_stock_hist_%` et les tables de prédiction le motif `pred_%`. Les suffixes doivent correspondre pour former une paire cohérente, par exemple : `fullsize_stock_hist_amz_man` et `pred_amz_man`.
 
+Les types d'activité valides sont :
+
+- `man` – activités manufacturières ;
+- `dis` – activités de distribution ;
+- `mixte` – activités mixtes combinant les deux.
+
+Ces valeurs forment la partie « activité » des noms de table.
+
 ### Création et alimentation des tables de test
 
 Pour le développement ou les tests locaux, créez une paire de tables historique/prédiction respectant les conventions ci-dessus. Exemple minimal :

--- a/db_utils.py
+++ b/db_utils.py
@@ -20,6 +20,56 @@ logger = logging.getLogger(__name__)
 
 _TABLE_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
+# Mapping from user provided activity type labels to the suffix used in
+# database table names. Keys are stored in lowercase so lookups can be
+# performed case-insensitively.
+_ACTIVITY_SUFFIX_MAP = {
+    "man": "man",
+    "manufacturing": "man",
+    "manufacturier": "man",
+    "dis": "dis",
+    "distribution": "dis",
+    "distributeur": "dis",
+    "mixte": "mixte",
+    "mix": "mixte",
+    "mixed": "mixte",
+}
+
+
+def get_activity_suffix(activity_type: str) -> str:
+    """Return the suffix used in table names for ``activity_type``.
+
+    Parameters
+    ----------
+    activity_type : str
+        Descriptor of the activity. The value is case-insensitive and may be
+        one of the following (with their aliases):
+
+        ``"man"``, ``"manufacturing"``, ``"manufacturier"`` -> ``"man"``
+        ``"dis"``, ``"distribution"``, ``"distributeur"`` -> ``"dis"``
+        ``"mixte"``, ``"mix"``, ``"mixed"`` -> ``"mixte"``
+
+    Returns
+    -------
+    str
+        The canonical suffix (``"man"``, ``"dis"`` or ``"mixte"``) used in
+        table names.
+
+    Raises
+    ------
+    ValueError
+        If ``activity_type`` is not recognised.
+    """
+
+    key = activity_type.strip().lower()
+    try:
+        return _ACTIVITY_SUFFIX_MAP[key]
+    except KeyError as exc:
+        valid = ", ".join(sorted(set(_ACTIVITY_SUFFIX_MAP)))
+        raise ValueError(
+            f"Unknown activity type '{activity_type}'. Expected one of: {valid}"
+        ) from exc
+
 
 def validate_table_name(table: str, engine: Optional[Engine] = None) -> None:
     """Validate a table name and optionally ensure it exists.

--- a/tests/test_activity_suffix.py
+++ b/tests/test_activity_suffix.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from db_utils import get_activity_suffix
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("man", "man"),
+        ("Manufacturing", "man"),
+        ("dis", "dis"),
+        ("Distribution", "dis"),
+        ("mixte", "mixte"),
+        ("Mixed", "mixte"),
+    ],
+)
+def test_get_activity_suffix_valid(value, expected):
+    assert get_activity_suffix(value) == expected
+
+
+@pytest.mark.parametrize("invalid", ["", "unknown", "abc"])
+def test_get_activity_suffix_invalid(invalid):
+    with pytest.raises(ValueError):
+        get_activity_suffix(invalid)


### PR DESCRIPTION
## Summary
- add `get_activity_suffix` utility mapping activity names to table suffixes
- document valid activity types in README
- test expected suffix mappings and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17916e928832d9bdee30cab553cb1