### PR TITLE
Add st.form example for batch deletion

### DIFF
--- a/pages/4_Suppression_Form.py
+++ b/pages/4_Suppression_Form.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import streamlit as st
+
+
+def main() -> None:
+    """Demonstrate batch deletion using st.form with st.data_editor.
+
+    This example avoids rerunning the app on every checkbox change by
+    wrapping the table in a form. Selections are applied only when the user
+    submits the form.
+    """
+    st.title("Gestion de suppression par lot")
+
+    if "data" not in st.session_state:
+        st.session_state.data = pd.DataFrame(
+            {
+                "Token": ["ORG_10", "ORG_11", "ORG_12"],
+                "Type": ["ORG", "ORG", "ORG"],
+                "Occurrences": [1, 4, 1],
+                "Valeurs": [
+                    "CONSEIL",
+                    "Société SAINT-GOBAIN",
+                    "SAINT-GOBAIN",
+                ],
+            }
+        )
+
+    df_display = st.session_state.data.copy()
+    df_display["Supprimer"] = False
+    df_display["Modifier"] = False
+    df_display["Fusionner"] = False
+
+    with st.form("edit_form"):
+        edited_df = st.data_editor(
+            df_display,
+            column_config={
+                "Supprimer": st.column_config.CheckboxColumn("Supprimer"),
+                "Modifier": st.column_config.CheckboxColumn("Modifier"),
+                "Fusionner": st.column_config.CheckboxColumn("Fusionner"),
+            },
+            key="data_table",
+        )
+        submit = st.form_submit_button("Valider les sélections")
+
+    if submit:
+        rows_to_drop = edited_df.index[edited_df["Supprimer"]]
+        if not rows_to_drop.empty:
+            st.session_state.data.drop(rows_to_drop, inplace=True)
+        st.experimental_rerun()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new Streamlit page demonstrating batch deletion using st.form to avoid reruns during checkbox selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b198016f44832d958ca9f6fefde56b