### PR TITLE
fix: replace experimental rerun with stable st.rerun

### DIFF
--- a/pages/4_Suppression_Form.py
+++ b/pages/4_Suppression_Form.py
@@ -45,7 +45,7 @@ def main() -> None:
         rows_to_drop = st.session_state.data.index[st.session_state.data["Supprimer"]]
         if not rows_to_drop.empty:
             st.session_state.data.drop(rows_to_drop, inplace=True)
-        st.experimental_rerun()
+        st.rerun()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun()` with `st.rerun()` in batch deletion page

## Testing
- `pytest`
- `streamlit run pages/4_Suppression_Form.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_68b19c57c3c8832dba158e4f4e632d12