### PR TITLE
Add anonymisation input and entity creation validation

### DIFF
--- a/tests/test_add_entity.py
+++ b/tests/test_add_entity.py
@@ -1,0 +1,23 @@
+import pytest
+import pages.recherche_avancee as ra
+
+
+def test_add_entity_stores_entity():
+    store = []
+    info = {"nb_occurrences": 1, "contextes": ["ctx"]}
+    ra.add_entity("Paris", "FR", info, store)
+    assert store == [
+        {
+            "token": "Paris",
+            "valeur_anonymisation": "FR",
+            "nb_occurrences": 1,
+            "contextes": ["ctx"],
+        }
+    ]
+
+
+def test_add_entity_requires_value():
+    store = []
+    info = {"nb_occurrences": 1, "contextes": []}
+    with pytest.raises(ValueError):
+        ra.add_entity("Paris", "", info, store)


### PR DESCRIPTION
## Summary
- add `add_entity` helper to validate anonymisation value and store entity data
- extend search page to capture anonymisation value, disable "Créer entité" button until filled and record entities in session state
- cover `add_entity` behaviour with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1aaeaa134832d8eeabf2c3cb06154