### PR TITLE
Add group table integration for entity creation

### DIFF
--- a/pages/recherche_avancee.py
+++ b/pages/recherche_avancee.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any, Dict, List
 
+import pandas as pd
 import streamlit as st
 
 
@@ -68,6 +69,34 @@ def add_entity(
     }
     store.append(entity)
 
+    cols = [
+        "Token",
+        "Type",
+        "Occurrences",
+        "Valeurs",
+        "Supprimer",
+        "Modifier",
+        "Fusionner",
+    ]
+    if "data" not in st.session_state:
+        st.session_state.data = pd.DataFrame(columns=cols)
+
+    type_value = value.split("_")[0] if "_" in value else "N/A"
+    new_row = pd.DataFrame(
+        {
+            "Token": [value],
+            "Type": [type_value],
+            "Occurrences": [info["nb_occurrences"]],
+            "Valeurs": [token],
+            "Supprimer": [False],
+            "Modifier": [False],
+            "Fusionner": [False],
+        }
+    )
+    st.session_state.data = pd.concat(
+        [st.session_state.data, new_row], ignore_index=True
+    )
+
 
 def main() -> None:
     st.set_page_config(page_title="Recherche avancée")
@@ -108,7 +137,7 @@ def main() -> None:
                         info,
                         st.session_state.entities,
                     )
-                    st.success("Entité ajoutée")
+                    st.experimental_rerun()
             with st.expander("Voir les contextes"):
                 for idx, ctx in enumerate(info["contextes"], start=1):
                     st.write(f"{idx}. …{ctx}…")

--- a/tests/test_search_entities.py
+++ b/tests/test_search_entities.py
@@ -1,4 +1,5 @@
 import pages.recherche_avancee as ra
+import streamlit as st
 
 
 def test_search_entities_groups_occurrences():
@@ -9,4 +10,16 @@ def test_search_entities_groups_occurrences():
     assert info["nb_occurrences"] == 2
     # Ensure we captured context for each occurrence
     assert len(info["contextes"]) == 2
-    assert all("Paris" in ctx for ctx in info["contextes"]) 
+    assert all("Paris" in ctx for ctx in info["contextes"])
+
+
+def test_add_entity_updates_group_store():
+    st.session_state.clear()
+    info = {"nb_occurrences": 1, "contextes": ["Paris"]}
+    store: list = []
+    ra.add_entity("Paris", "ORG_99", info, store)
+    assert store[0]["valeur_anonymisation"] == "ORG_99"
+    assert "data" in st.session_state
+    df = st.session_state.data
+    assert df.iloc[0]["Token"] == "ORG_99"
+    assert df.iloc[0]["Valeurs"] == "Paris"


### PR DESCRIPTION
## Summary
- Append new entities to the shared group DataFrame when created in advanced search
- Refresh page after entity creation for immediate visibility
- Test entity creation updates group store

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac387818832da45641f7e4389e54